### PR TITLE
Display summary in HTTP error response codes

### DIFF
--- a/angular-app/app/def/baker.yaml
+++ b/angular-app/app/def/baker.yaml
@@ -119,10 +119,16 @@ traits:
           Location:
             type: string
             description: Location of the newly created issue
+      403:
+        summary: Unauthorized
+        description: |
+          The user is not allowed to create issues
   get:
     summary: List all issues available to Baker
     responses:
       200:
+        summary: OK
+        description: this is a test
         body:
           application/json:
             schema: |

--- a/angular-app/app/views/raml-operation-details-response.tmpl.html
+++ b/angular-app/app/views/raml-operation-details-response.tmpl.html
@@ -1,7 +1,7 @@
 <section role="api-operation-details-section-response" ng-controller="ramlOperationDetailsResponse">
   <section role="codes-list" ng-repeat="(statusCode, response) in operation.responses">
     <header>
-      <h1>{{statusCode}}</h1>
+      <h1>{{statusCode}}<small ng-show="response.summary">:&nbsp;{{response.summary}}</small></h1>
       <p>{{response.description}}</p>
     </header>
 


### PR DESCRIPTION
Now the summary is displayed next to the HTTP response code

![image](https://f.cloud.github.com/assets/1288192/1058147/1260c0d0-1183-11e3-963d-f6c6862f9041.png)
