### PR TITLE
Console invokes the ramlReader on new raml data.

### DIFF
--- a/app/scripts/directives/raml-console.js
+++ b/app/scripts/directives/raml-console.js
@@ -16,7 +16,7 @@ angular.module('ramlConsoleApp')
                 $scope.resources = [];
                 $scope.consoleSettings = { displayTryIt: true };
 
-                $rootScope.$on('event:raml-parsed', function (e, args) {
+                $scope.$on('event:raml-parsed', function (e, args) {
                     var definition = ramlReader.read(args)
                     $scope.baseUri = ramlReader.processBaseUri(definition);
                     $scope.resources = definition.resources;


### PR DESCRIPTION
While the ramlReader is defined by the console and its output is
consumed by the console, it is invoked by the editor before notifying
the console of a change to the current raml file.

This commit inverts that relationship making the ramlReader a self
contained concern.

Previously, the event listener was registed upon using the raml-console
directive.  This won't work moving forward as the editor does not use
this directive. For now, we register a run directive which wires up the
event listener.  This is a short term solution as the console UI rework
is beginning soon.
