### PR TITLE
Adapt editorconfig to project conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,12 +4,11 @@
 
 root = true
 
-
 [*]
 
 # Change these settings to your own preference
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 # We recommend you to keep these unchanged
 end_of_line = lf


### PR DESCRIPTION
The rules in the `.editorconfig` don't seem to be correct as the project is using 2 spaces in almost all places.