### PR TITLE
Provide a default parameter colour

### DIFF
--- a/app/styles/forms.less
+++ b/app/styles/forms.less
@@ -92,6 +92,7 @@ input[type="text"], input[type="password"] {
 }
 
 .parameter-field-input input[type="text"] {
+  color: @gray6;
   font-size: 12px;
   padding: 1px 3px;
 }


### PR DESCRIPTION
When the console is being used with other CSS rules, such as a simple `color: inherit` on inputs, the parameter inputs are inheriting the white text colour from the url string under “Try It”.
