### PR TITLE
Fixed the scrollbar that disappeared in Firefox 34

### DIFF
--- a/app/styles/documentation.less
+++ b/app/styles/documentation.less
@@ -1,5 +1,6 @@
 .documentation {
   display: flex;
+  min-height: 0;
   flex: 1;
   flex-direction: column;
 

--- a/app/styles/methods.less
+++ b/app/styles/methods.less
@@ -14,6 +14,7 @@
 .method-nav(@color, @mediumColor, @lightColor) {
   .method-nav-container {
     display: flex;
+    min-height: 0;
     flex-direction: column;
     flex: 1;
   }
@@ -87,6 +88,7 @@
   .method-content-container {
     overflow: auto;
     display: flex;
+    min-height: 0;
     flex-direction: column;
     flex: 1;
     padding: 0 10px;
@@ -120,6 +122,7 @@
   margin: 0 -8px 10px -10px;
   background: white;
   display: flex;
+  min-height: 0;
   flex-direction: column;
 
   &:first-child {


### PR DESCRIPTION
The scrollbar which disappeared in Firefox 34 (due to flexbox changes) is back.

See: https://developer.mozilla.org/en-US/Firefox/Releases/34/Site_Compatibility#CSS