### PR TITLE
Response body size calculation bug

### DIFF
--- a/src/app/directives/sidebar.js
+++ b/src/app/directives/sidebar.js
@@ -84,8 +84,8 @@
           var editorHeight = 50;
 
           if (jqXhr.responseText) {
-            var lines = jqXhr.responseText.split('\n').length;
-            editorHeight = lines > 100 ? 2000 : 25*lines;
+            var lines = $scope.response.body.split('\n').length;
+            editorHeight = lines > 100 ? 2000 : Math.ceil(20.3 * lines);
           }
 
           $scope.editorStyle = {


### PR DESCRIPTION
Response body height was set to raw response height instead of beautified response height. The line height used was also wrong.
