### PR TITLE
Fixes tryit with query parameters defined in custom auth scheme

### DIFF
--- a/dist/scripts/api-console.js
+++ b/dist/scripts/api-console.js
@@ -958,6 +958,10 @@
             $scope.methodInfo.headers.plain = {};
           }
 
+          if (!$scope.methodInfo.queryParameters) {
+            $scope.methodInfo.queryParameters = {};
+          }
+
           updateContextData('headers', name, $scope.methodInfo.headers.plain, $scope.context.headers);
           updateContextData('queryParameters', name, $scope.methodInfo.queryParameters, $scope.context.queryParameters);
         }

--- a/src/app/directives/sidebar.js
+++ b/src/app/directives/sidebar.js
@@ -21,6 +21,10 @@
             $scope.methodInfo.headers.plain = {};
           }
 
+          if (!$scope.methodInfo.queryParameters) {
+            $scope.methodInfo.queryParameters = {};
+          }
+
           updateContextData('headers', name, $scope.methodInfo.headers.plain, $scope.context.headers);
           updateContextData('queryParameters', name, $scope.methodInfo.queryParameters, $scope.context.queryParameters);
         }


### PR DESCRIPTION
Hey there. Currently the try-it functionality breaks when using custom auth scheme with required query parameters.
Here is the scheme definition I use:

```
- auth_token:
    type: x-custom
    describedBy:
      description: Request authentication
      queryParameters:
        auth_token:
          description: Unique authentication token
```

It raises a `TypeError: Cannot set property 'auth_token' of undefined` in the console.
Hopefully this is the right way to fix it.

Thanks !