### PR TITLE
Force support of UTF-8 for SASS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -183,7 +183,8 @@ module.exports = function (grunt) {
       build: {
         options: {
           sourcemap: 'none',
-          style:     'expanded'
+          style:     'expanded',
+          defaultEncoding: 'UTF-8'
         },
 
         files: {
@@ -195,7 +196,8 @@ module.exports = function (grunt) {
       min: {
         options: {
           sourcemap: 'none',
-          style:     'compressed'
+          style:     'compressed',
+          defaultEncoding: 'UTF-8'
         },
 
         files: {


### PR DESCRIPTION
This commit fixes `Warning: Error: Invalid US-ASCII character "\xE2"`
happening for `src/scss/light-theme.scss` and `src/scss/dark-theme.scss`.