### PR TITLE
Add Dockerfile to run RAML API Console

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:4.1
+
+# Install Ruby (for Gem)
+RUN apt-get update \
+    && apt-get install -y ruby \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Bower, Grunt & SASS
+RUN npm install -g bower grunt-cli \
+    && gem install sass
+
+# Define working directory.
+WORKDIR /data
+
+COPY . /data
+
+RUN npm install && bower --allow-root install
+
+EXPOSE 9000
+
+ENTRYPOINT ["/usr/local/bin/grunt"]
+CMD ["default"]

--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "https://github.com/mulesoft/api-console.git"
   },
+  "ignore": [ "Dockerfile" ],
   "dependencies": {
     "angular": "~1.3.17",
     "angular-highlightjs": "~0.3.2",


### PR DESCRIPTION
The `Dockerfile` builds an image that could run the `api-console`
within a container. It provides the required environment to
run the application seamlessly on your machine or server.

Depends on: PR #181 (UTF-8 support for SASS)