### PR TITLE
added toggable security check to only allow loading of Raml Urls whic…

### DIFF
--- a/src/app/directives/raml-console-loader.js
+++ b/src/app/directives/raml-console-loader.js
@@ -40,21 +40,25 @@
         $scope.vm.loaded = false;
         $scope.vm.error  = void(0);
 
-        return ramlParser.loadPath($window.resolveUrl(url), null, $scope.options)
-          .then(function (raml) {
-            $scope.vm.raml = raml;
-          })
-          .catch(function (error) {
-            $scope.vm.error = angular.extend(error, {
-              /*jshint camelcase: false */
-              buffer: (error.context_mark || error.problem_mark).buffer
-              /*jshint camelcase: true */
-            });
-          })
-          .finally(function () {
-            $scope.vm.loaded = true;
-          })
-        ;
+        if(RAML.LoaderUtils.ramlOriginValidate(url, $scope.options)) {
+          $scope.vm.error = {buffer : 'RAML origin check failed. Raml does not reside underneath the path:' + RAML.LoaderUtils.allowedRamlOrigin($scope.options)};
+        } else {
+          return ramlParser.loadPath($window.resolveUrl(url), null, $scope.options)
+            .then(function (raml) {
+              $scope.vm.raml = raml;
+            })
+            .catch(function (error) {
+              $scope.vm.error = angular.extend(error, {
+                /*jshint camelcase: false */
+                buffer: (error.context_mark || error.problem_mark).buffer
+                /*jshint camelcase: true */
+              });
+            })
+            .finally(function () {
+              $scope.vm.loaded = true;
+            })
+          ;
+        }
       }
     })
   ;

--- a/src/app/directives/raml-initializer.js
+++ b/src/app/directives/raml-initializer.js
@@ -7,7 +7,10 @@
         restrict:    'E',
         templateUrl: 'directives/raml-initializer.tpl.html',
         replace:     true,
-        controller:  'RamlInitializerController'
+        controller:  'RamlInitializerController',
+        scope:       {
+          options: '='
+        }
       };
     })
     .controller('RamlInitializerController', function RamlInitializerController(
@@ -46,7 +49,13 @@
 
       function loadFromUrl(url) {
         $scope.vm.ramlUrl = url;
-        return loadFromPromise(ramlParser.loadPath($window.resolveUrl(url)), {isLoadingFromUrl: true});
+
+        if(RAML.LoaderUtils.ramlOriginValidate(url, $scope.options)) {
+          $scope.vm.isLoadedFromUrl = true;
+          $scope.vm.error = {message : 'RAML origin check failed. Raml does not reside underneath the path:' + RAML.LoaderUtils.allowedRamlOrigin($scope.options)};
+        } else {
+          return loadFromPromise(ramlParser.loadPath($window.resolveUrl(url)), {isLoadingFromUrl: true});
+        }
       }
 
       function loadFromString(string) {

--- a/src/common/loader_utils.js
+++ b/src/common/loader_utils.js
@@ -1,0 +1,34 @@
+(function() {
+  'use strict';
+
+  RAML.LoaderUtils = {
+
+    allowedRamlOrigin : function(options) {
+      var basepath='../';
+      if(typeof options.ramlOriginCheck === 'string') {
+        basepath = options.ramlOriginCheck;
+      }
+      return basepath;
+    },
+
+    // prevent loading stuff from other hosts and/or services
+    ramlOriginValidate: function (url, options) {
+      var absolutePath = function(href) {
+          var link = document.createElement('a');
+          link.href = href;
+          return link.href;
+      };
+
+      var isSameBasePath = function(href, basepath) {
+          var absoluteBasepath=absolutePath(basepath);
+          var absoluteRamlPath=absolutePath(href);
+          return absoluteRamlPath.indexOf(absoluteBasepath, 0) === 0;
+      };
+
+      var decodedRamlUrl=decodeURIComponent(url);
+      return options && options.ramlOriginCheck && !isSameBasePath(decodedRamlUrl, RAML.LoaderUtils.allowedRamlOrigin(options));
+    }
+
+
+  };
+})();


### PR DESCRIPTION
The api-console can be deployed by a user/company to load the RAML API descriptors of it's services. This instance of the deployed api-console can be misused to load a RAML file which is hosted in a different place than the company's own servers and it will be difficult for the users to notice it since the api-console's URL will still be the one of the api-console hosted by the attacked company.

This pull request enables an "option" for the "raml-console-initialiazer" and "raml-console-loader" (where loading from URL is done...) to restrict the loading of RAML files to only those for which the absolute URL is prefixed with either  a specified value:

options="{ramlOriginCheck:'http://myRamlPathPrefix/'}" 

or with the default value 

options="{ramlOriginCheck:true}"

which defaults to the "../" path.
