### PR TITLE
Bump API console version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "api-console",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/mulesoft/api-console.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-console",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Api-Console for RAML based app",
   "files": [
     "dist",


### PR DESCRIPTION
- This new release is intended to fix the issue of crypto-js dependency going offline.