### PR TITLE
Show type documentation for non-native types in the request body too

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -285,7 +285,8 @@ module.exports = function (grunt) {
 
     jshint: {
       options: {
-        jshintrc: true
+        jshintrc: true,
+        reporterOutput: ''
       },
 
       files: [

--- a/dist/scripts/api-console.js
+++ b/dist/scripts/api-console.js
@@ -2594,6 +2594,11 @@
 
         $scope.cleanupTypeName = RAML.Inspector.Types.cleanupTypeName;
 
+        $scope.typeDocumentation = function(type) {
+          type = RAML.Inspector.Types.findType(type.type[0], $rootScope.types);
+          return RAML.Inspector.Types.typeDocumentation(type);
+        };
+
         $scope.getSupertTypes = function (type) {
           return RAML.Inspector.Types.findType(type.type[0], $rootScope.types).type.map(function (aTypeName) {
             return aTypeName;
@@ -4368,6 +4373,61 @@ RAML.Inspector = (function() {
     return Array.isArray(type) ? type : [type];
   }
 
+  function typeDocumentation(type) {
+    var result = [];
+
+    if (type.minItems) {
+      result.push('minItems: ' + type.minItems);
+    }
+
+    if (type.maxItems) {
+      result.push('maxItems: ' + type.maxItems);
+    }
+
+    if (type['enum']) {
+      var enumValues = type['enum'];
+      var enumDescription = '';
+
+      if (enumValues.length > 1) {
+        enumDescription += 'one of ';
+      }
+
+      enumDescription += '(' + enumValues.filter(function (value) { return value !== ''; }).join(', ') + ')';
+
+      result.push(enumDescription);
+    }
+
+    if (type.pattern) {
+      result.push('pattern: ' + type.pattern);
+    }
+
+    if (type.minLength) {
+      result.push('minLength: ' + type.minLength);
+    }
+
+    if (type.maxLength) {
+      result.push('maxLength: ' + type.maxLength);
+    }
+
+    if (type.minimum) {
+      result.push('minimum: ' + type.minimum);
+    }
+
+    if (type.format) {
+      result.push('format: ' + type.format);
+    }
+
+    if (type.multipleOf) {
+      result.push('multipleOf: ' + type.multipleOf);
+    }
+
+    if (type.fileTypes) {
+      result.push('fileTypes: ' + type.fileTypes.join(', '));
+    }
+
+    return result.join(', ');
+  }
+
   RAML.Inspector.Types = {
     mergeType:           mergeType,
     isNativeType:        isNativeType,
@@ -4377,7 +4437,8 @@ RAML.Inspector = (function() {
     getTypeInfo:         getTypeInfo,
     getTypeFromTypeInfo: getTypeFromTypeInfo,
     ensureArray:         ensureArray,
-    cleanupTypeName:     cleanupTypeName
+    cleanupTypeName:     cleanupTypeName,
+    typeDocumentation:   typeDocumentation
   };
 })();
 
@@ -7407,6 +7468,7 @@ angular.module('ramlConsoleApp').run(['$templateCache', function($templateCache)
     "<div ng-if=\"selectedType\" class=\"raml-console-type-info-popover\">\n" +
     "  <h3>\n" +
     "    <span>{{selectedType.displayName}}</span>\n" +
+    "    <span class=\"raml-console-resource-param-instructional\">{{typeDocumentation(selectedType)}}</span>\n" +
     "    <div class=\"raml-console-subtitle\">\n" +
     "      <span ng-repeat-start=\"superType in getSupertTypes(selectedType)\">{{superType}}</span>\n" +
     "      <span ng-if=\"!$last\" ng-repeat-end>, </span>\n" +

--- a/src/app/directives/type.js
+++ b/src/app/directives/type.js
@@ -28,6 +28,11 @@
 
         $scope.cleanupTypeName = RAML.Inspector.Types.cleanupTypeName;
 
+        $scope.typeDocumentation = function(type) {
+          type = RAML.Inspector.Types.findType(type.type[0], $rootScope.types);
+          return RAML.Inspector.Types.typeDocumentation(type);
+        };
+
         $scope.getSupertTypes = function (type) {
           return RAML.Inspector.Types.findType(type.type[0], $rootScope.types).type.map(function (aTypeName) {
             return aTypeName;

--- a/src/app/directives/type.tpl.html
+++ b/src/app/directives/type.tpl.html
@@ -9,6 +9,7 @@
 <div ng-if="selectedType" class="raml-console-type-info-popover">
   <h3>
     <span>{{selectedType.displayName}}</span>
+    <span class="raml-console-resource-param-instructional">{{typeDocumentation(selectedType)}}</span>
     <div class="raml-console-subtitle">
       <span ng-repeat-start="superType in getSupertTypes(selectedType)">{{superType}}</span>
       <span ng-if="!$last" ng-repeat-end>, </span>

--- a/src/common/inspector/types.js
+++ b/src/common/inspector/types.js
@@ -154,6 +154,61 @@
     return Array.isArray(type) ? type : [type];
   }
 
+  function typeDocumentation(type) {
+    var result = [];
+
+    if (type.minItems) {
+      result.push('minItems: ' + type.minItems);
+    }
+
+    if (type.maxItems) {
+      result.push('maxItems: ' + type.maxItems);
+    }
+
+    if (type['enum']) {
+      var enumValues = type['enum'];
+      var enumDescription = '';
+
+      if (enumValues.length > 1) {
+        enumDescription += 'one of ';
+      }
+
+      enumDescription += '(' + enumValues.filter(function (value) { return value !== ''; }).join(', ') + ')';
+
+      result.push(enumDescription);
+    }
+
+    if (type.pattern) {
+      result.push('pattern: ' + type.pattern);
+    }
+
+    if (type.minLength) {
+      result.push('minLength: ' + type.minLength);
+    }
+
+    if (type.maxLength) {
+      result.push('maxLength: ' + type.maxLength);
+    }
+
+    if (type.minimum) {
+      result.push('minimum: ' + type.minimum);
+    }
+
+    if (type.format) {
+      result.push('format: ' + type.format);
+    }
+
+    if (type.multipleOf) {
+      result.push('multipleOf: ' + type.multipleOf);
+    }
+
+    if (type.fileTypes) {
+      result.push('fileTypes: ' + type.fileTypes.join(', '));
+    }
+
+    return result.join(', ');
+  }
+
   RAML.Inspector.Types = {
     mergeType:           mergeType,
     isNativeType:        isNativeType,
@@ -163,6 +218,7 @@
     getTypeInfo:         getTypeInfo,
     getTypeFromTypeInfo: getTypeFromTypeInfo,
     ensureArray:         ensureArray,
-    cleanupTypeName:     cleanupTypeName
+    cleanupTypeName:     cleanupTypeName,
+    typeDocumentation:   typeDocumentation
   };
 })();


### PR DESCRIPTION
Right now, if a string enum is used as a special type, then despite showing up as a link in the request body, the popup for the link doesn't show anything about the enum. It's pretty non-informative for an enum string to show up as just "<nameOfType> string". Ideally, it should show "<nameOfType> one of (<value1>,<value2>,...) string".

Fortunately, for the Types panel, a `function typeDocumentation(type)` already existed. Extracting that into `RAML.Inspector.Types` and using it from both the Types panel and resource bodies was a straightforward change.