### PR TITLE
Fix background color of Types panel in dark theme

### DIFF
--- a/dist/scripts/api-console.js
+++ b/dist/scripts/api-console.js
@@ -7156,7 +7156,7 @@ angular.module('ramlConsoleApp').run(['$templateCache', function($templateCache)
     "      </div>\n" +
     "    </header>\n" +
     "  </li>\n" +
-    "  <li ng-if=\"!vm.isCollapsed\" class=\"raml-console-resource-panel raml-console-type-panel\" style=\"background: white; padding: 32px;\">\n" +
+    "  <li ng-if=\"!vm.isCollapsed\" class=\"raml-console-resource-panel raml-console-type-panel\" style=\"padding: 32px;\">\n" +
     "    <properties list=\"theTypes\" collapsible=\"true\" hide-property-details=\"true\"></types>\n" +
     "  </li>\n" +
     "</ol>\n"

--- a/src/app/directives/root-types.tpl.html
+++ b/src/app/directives/root-types.tpl.html
@@ -9,7 +9,7 @@
       </div>
     </header>
   </li>
-  <li ng-if="!vm.isCollapsed" class="raml-console-resource-panel raml-console-type-panel" style="background: white; padding: 32px;">
+  <li ng-if="!vm.isCollapsed" class="raml-console-resource-panel raml-console-type-panel" style="padding: 32px;">
     <properties list="theTypes" collapsible="true" hide-property-details="true"></types>
   </li>
 </ol>


### PR DESCRIPTION
The Types panel had a correct background color assigned in the dark theme, but also a specific background color of white hardcoded into its markup.

The latter is both redundant and in the way of the dark theme, rendering the names of the types unreadable under a dark theme.