### PR TITLE
Add an option to seamlessly work with Cross-Site Request Forgery (CSRF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ In *Single View* mode you will be able to see only documentation or try-it.
 
     <raml-console-loader src="path-to-raml" disable-try-it></raml-console-loader>    
 
+### Enable seamlessly CSRF
+
+When *csrfPath* is set, for every destructive request, if previously no csrf token was fetched, will try to fetch a CSRF token from `baseUri + csrfPath` url, before performing the current request. E.g.:
+
+    <raml-console-loader src="path-to-raml" options="{ csrfPath: '/yourcsrfEndPoint' }"></raml-console-loader>    
+
 ## Development
 
 ### Prerequisites

--- a/dist/scripts/api-console.js
+++ b/dist/scripts/api-console.js
@@ -1862,6 +1862,56 @@
 (function () {
   'use strict';
 
+  var csrf = {};
+
+  //Need to be set only once
+  jQuery.ajaxPrefilter(function (options, originalOptions, _jqXHR) {
+    var csrfUrl = options.url.replace(/\/rest\/.*/g,'/rest/csrf');
+    var apiCSRF = csrf[csrfUrl];
+    if (apiCSRF) {
+      if (["POST", "PUT", "DELETE", "PATCH"].indexOf(options.type.toUpperCase()) !== -1) {
+        _jqXHR.setRequestHeader("X-CSRF-Token", apiCSRF);
+      }
+    }
+  });
+  var CSRF = {
+    initialize: function (url) {
+      try {
+        var csrfPromise = jQuery.Deferred();
+
+        if (csrf[url]) {
+          return csrfPromise.resolve();
+        }
+
+        //Need to be set only once
+        var requestPromise = jQuery.ajax({
+          url: url,
+          method: "GET",
+          headers: { "X-CSRF-Token": "Fetch" },
+          async: false
+        });
+
+        requestPromise
+          .then(function (data, sStatus, jqXHR) {
+            //if (data) { location.reload(); } // Reload page if session timed out
+
+            //Need to be set only once
+            csrf[url] = jqXHR.getResponseHeader("X-CSRF-Token");
+            console.log('successfull csrf', csrf, url);
+
+            csrfPromise.resolve.apply(this, arguments);
+          }, function(jqXHR) {
+            console.error('error', arguments);
+            csrfPromise.resolve.apply(this, arguments);
+          });
+        return csrfPromise;
+      }catch(ex) {
+        console.error(ex);
+        return csrfPromise.resolve();
+      }
+    }
+  };
+
   RAML.Directives.sidebar = function() {
     return {
       restrict: 'E',
@@ -2357,10 +2407,13 @@
               authStrategy.authenticate().then(function(token) {
                 token.sign(request);
                 $scope.requestOptions = request.toOptions();
-                jQuery.ajax(request.toOptions()).then(
-                  function(data, textStatus, jqXhr) { handleResponse(jqXhr); },
-                  function(jqXhr) { handleResponse(jqXhr); }
-                );
+                CSRF.initialize(client.baseUri + '/csrf')
+                .then(function() {
+                  jQuery.ajax(request.toOptions()).then(
+                    function(data, textStatus, jqXhr) { handleResponse(jqXhr); },
+                    function(jqXhr) { handleResponse(jqXhr); }
+                  );
+                });
               });
 
               $scope.requestOptions = request.toOptions();

--- a/dist/scripts/api-console.js
+++ b/dist/scripts/api-console.js
@@ -1278,6 +1278,7 @@
       $scope.hasResourcesWithChilds     = hasResourcesWithChilds;
       $scope.toggle                     = toggle;
       $scope.updateProxyConfig          = updateProxyConfig;
+      $scope.csrfPath                   = $attrs.hasOwnProperty('csrfPath') && $attrs['csrfPath'];
 
       // ---
 
@@ -1296,7 +1297,9 @@
             $scope[property] = true;
           }
         });
-        $scope.csrfPath = $scope.options['csrfPath'];
+        if ($scope.options) {
+          $scope.csrfPath = $scope.options['csrfPath'];
+        }
 
         $scope.$watch('raml', function (raml) {
           if (!raml) {

--- a/src/app/directives/raml-console.js
+++ b/src/app/directives/raml-console.js
@@ -14,7 +14,7 @@
         }
       };
     })
-    .controller('RamlConsoleController', 
+    .controller('RamlConsoleController',
       ['$attrs', '$scope', '$rootScope', '$timeout', '$window', function RamlConsoleController(
       $attrs, $scope, $rootScope, $timeout, $window
     ) {
@@ -51,6 +51,7 @@
             $scope[property] = true;
           }
         });
+        $scope.csrfPath = $scope.options['csrfPath'];
 
         $scope.$watch('raml', function (raml) {
           if (!raml) {

--- a/src/app/directives/raml-console.js
+++ b/src/app/directives/raml-console.js
@@ -33,6 +33,7 @@
       $scope.hasResourcesWithChilds     = hasResourcesWithChilds;
       $scope.toggle                     = toggle;
       $scope.updateProxyConfig          = updateProxyConfig;
+      $scope.csrfPath                   = $attrs.hasOwnProperty('csrfPath') && $attrs['csrfPath'];
 
       // ---
 
@@ -51,7 +52,9 @@
             $scope[property] = true;
           }
         });
-        $scope.csrfPath = $scope.options['csrfPath'];
+        if ($scope.options) {
+          $scope.csrfPath = $scope.options['csrfPath'];
+        }
 
         $scope.$watch('raml', function (raml) {
           if (!raml) {

--- a/src/app/directives/sidebar.js
+++ b/src/app/directives/sidebar.js
@@ -1,6 +1,56 @@
 (function () {
   'use strict';
 
+  var csrf = {};
+
+  //Need to be set only once
+  jQuery.ajaxPrefilter(function (options, originalOptions, _jqXHR) {
+    var csrfUrl = options.url.replace(/\/rest\/.*/g,'/rest/csrf');
+    var apiCSRF = csrf[csrfUrl];
+    if (apiCSRF) {
+      if (["POST", "PUT", "DELETE", "PATCH"].indexOf(options.type.toUpperCase()) !== -1) {
+        _jqXHR.setRequestHeader("X-CSRF-Token", apiCSRF);
+      }
+    }
+  });
+  var CSRF = {
+    initialize: function (url) {
+      try {
+        var csrfPromise = jQuery.Deferred();
+
+        if (csrf[url]) {
+          return csrfPromise.resolve();
+        }
+
+        //Need to be set only once
+        var requestPromise = jQuery.ajax({
+          url: url,
+          method: "GET",
+          headers: { "X-CSRF-Token": "Fetch" },
+          async: false
+        });
+
+        requestPromise
+          .then(function (data, sStatus, jqXHR) {
+            //if (data) { location.reload(); } // Reload page if session timed out
+
+            //Need to be set only once
+            csrf[url] = jqXHR.getResponseHeader("X-CSRF-Token");
+            console.log('successfull csrf', csrf, url);
+
+            csrfPromise.resolve.apply(this, arguments);
+          }, function(jqXHR) {
+            console.error('error', arguments);
+            csrfPromise.resolve.apply(this, arguments);
+          });
+        return csrfPromise;
+      }catch(ex) {
+        console.error(ex);
+        return csrfPromise.resolve();
+      }
+    }
+  };
+
   RAML.Directives.sidebar = function() {
     return {
       restrict: 'E',
@@ -496,10 +546,13 @@
               authStrategy.authenticate().then(function(token) {
                 token.sign(request);
                 $scope.requestOptions = request.toOptions();
-                jQuery.ajax(request.toOptions()).then(
-                  function(data, textStatus, jqXhr) { handleResponse(jqXhr); },
-                  function(jqXhr) { handleResponse(jqXhr); }
-                );
+                CSRF.initialize(client.baseUri + '/csrf')
+                .then(function() {
+                  jQuery.ajax(request.toOptions()).then(
+                    function(data, textStatus, jqXhr) { handleResponse(jqXhr); },
+                    function(jqXhr) { handleResponse(jqXhr); }
+                  );
+                });
               });
 
               $scope.requestOptions = request.toOptions();


### PR DESCRIPTION
Hi everyone,

in our company, we use api-console since quite a long time and we find the need to add a header for every destructive request to work with CSRF, a time-consuming and error-prone activity.
Now that we released our product, more people is dealing with the same problem.

Here, I present you a possible solution consisting on adding a new option called `csrfPath` that when set, for every destructive request, if previously no csrf token was fetched, will try to fetch a CSRF token from `baseUri + csrfPath` url, before performing the current request.
If something goes wrong while fetching the csrf token it won't affect the current request.