### PR TITLE
Docker build fails - update node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.1
+FROM node:4.7
 
 # Install Ruby (for Gem)
 RUN apt-get update \


### PR DESCRIPTION
Building the Docker image failed.  A bump of the node version from 4.1 to 4.7 seemed to work.
Here is the docker build error:

> git clone git@github.com:mulesoft/api-console.git
> sudo docker build .
> ...
> ERROR:  Loading command: install (LoadError)
> 	/usr/lib/x86_64-linux-gnu/ruby/2.1.0/openssl.so: symbol SSLv2_method, version OPENSSL\
> _1.0.0 not defined in file libssl.so.1.0.0 with link time reference - /usr/lib/x86_64-linux-g\
> nu/ruby/2.1.0/openssl.so
> ERROR:  While executing gem ... (NoMethodError)
>     undefined method `invoke_with_build_args' for nil:NilClass

