### PR TITLE
typo in License name

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "api"
   ],
   "author": "MuleSoft, Inc.",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/mulesoft/api-console/issues"
   },


### PR DESCRIPTION
When trying to build a npm webjar for the console. I get following message:

```
Failed!
All attempts to determine an acceptable license have been exhausted. The package.json file did not contain a spec-compliant license definition and the license could not be determined by trolling through the source repo: https://github.com/mulesoft/api-console
The acceptable open source software licenses are at: https://bintray.com/docs/api/#_footnote_1
The provided licenses were: Apache 2.0
This problem will likely need to be resolved by working with the library maintainers directly.
If you feel you have reached this failure in error, please file an issue: https://github.com/webjars/webjars/issues

Got NPM info
Determined Artifact Name: api-console
Starting Deploy
```

In order to fix this issue the license name has to be changed slightly.