### PR TITLE
changed license name for the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "api"
   ],
   "author": "MuleSoft, Inc.",
-  "license": "Apache-2.0",
+  "license": "CPAL-1.0",
   "bugs": {
     "url": "https://github.com/mulesoft/api-console/issues"
   },


### PR DESCRIPTION
Since we use CPAL-1.0 as our license, the npm package should reflect that as well.