### PR TITLE
Update api-console build options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ sudo npm install -g api-console-cli
 Generate API console from your RAML or OAS file:
 
 ```shell
-$ api-console build -t "RAML 1.0" -a path/to/api.raml # works with remote files too
+$ NODE_OPTIONS=--max_old_space_size=2048 api-console build -t "RAML 1.0" -a path/to/api.raml # works with remote files too
 ```
 
 Preview the console:


### PR DESCRIPTION
Building even the most minimal RAML file fails for me without this option, and as #588 says ...

> I don't see how this could be optimised right now.

... then this should probably be added to the README.

Fixes #588