### PR TITLE
feat(server): update api-documentation that allows server selection

### DIFF
--- a/demo/element/app.js
+++ b/demo/element/app.js
@@ -49,7 +49,8 @@ class ApicApplication extends DemoBase {
 
       <api-console
         redirecturi="https://auth.advancedrestclient.com/oauth-popup.html"
-        oauth2clientid="821776164331-rserncqpdsq32lmbf5cfeolgcoujb6fm.apps.googleusercontent.com">
+        oauth2clientid="821776164331-rserncqpdsq32lmbf5cfeolgcoujb6fm.apps.googleusercontent.com"
+        narrow>
       </api-console>
 
       <xhr-simple-request></xhr-simple-request>

--- a/demo/element/app.js
+++ b/demo/element/app.js
@@ -49,8 +49,7 @@ class ApicApplication extends DemoBase {
 
       <api-console
         redirecturi="https://auth.advancedrestclient.com/oauth-popup.html"
-        oauth2clientid="821776164331-rserncqpdsq32lmbf5cfeolgcoujb6fm.apps.googleusercontent.com"
-        narrow>
+        oauth2clientid="821776164331-rserncqpdsq32lmbf5cfeolgcoujb6fm.apps.googleusercontent.com">
       </api-console>
 
       <xhr-simple-request></xhr-simple-request>

--- a/package-lock.json
+++ b/package-lock.json
@@ -740,9 +740,9 @@
       }
     },
     "@api-components/api-documentation": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-documentation/-/api-documentation-4.1.0.tgz",
-      "integrity": "sha512-rpIRhhaihyYXgPZ+kyodDgnkgG4BnalPu/ziTgHuThD7nNyw3f5Gm+lhv5k6V3Q5suzWEdh8U4/BjhgGuvufCw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@api-components/api-documentation/-/api-documentation-4.1.1.tgz",
+      "integrity": "sha512-qGLO+Zj6iFKLgB6/quPc4KpecpZOwIbmKAbLISmS6h16SJDfqP9OPU+A/5tWUW1GuQ2ryHUR6ZSNwrQWHFYJEA==",
       "requires": {
         "@advanced-rest-client/events-target-mixin": "^3.0.0",
         "@api-components/amf-helper-mixin": "^4.0.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -740,15 +740,17 @@
       }
     },
     "@api-components/api-documentation": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@api-components/api-documentation/-/api-documentation-4.0.5.tgz",
-      "integrity": "sha512-Ylh7TvTYhEcKW4m0/EyZPuGnN+91qZ8G54OBuwjYzwF/hBCTdttiWSzcgI0cFCR28UjselDNddeukof7/dbI9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@api-components/api-documentation/-/api-documentation-4.1.0.tgz",
+      "integrity": "sha512-rpIRhhaihyYXgPZ+kyodDgnkgG4BnalPu/ziTgHuThD7nNyw3f5Gm+lhv5k6V3Q5suzWEdh8U4/BjhgGuvufCw==",
       "requires": {
+        "@advanced-rest-client/events-target-mixin": "^3.0.0",
         "@api-components/amf-helper-mixin": "^4.0.17",
         "@api-components/api-documentation-document": "^4.0.2",
         "@api-components/api-endpoint-documentation": "^4.0.4",
         "@api-components/api-method-documentation": "^4.0.7",
         "@api-components/api-security-documentation": "^4.0.5",
+        "@api-components/api-server-selector": "^0.2.1",
         "@api-components/api-summary": "^4.0.2",
         "@api-components/api-type-documentation": "^4.0.3",
         "@api-components/raml-aware": "^3.0.0",
@@ -1047,6 +1049,23 @@
         "@api-components/api-responses-document": "^4.0.1",
         "@api-components/raml-aware": "^3.0.0",
         "lit-element": "^2.2.1"
+      }
+    },
+    "@api-components/api-server-selector": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@api-components/api-server-selector/-/api-server-selector-0.2.4.tgz",
+      "integrity": "sha512-wq3far3lRrnl99SMDuKlNzplMcqolhYo+46ljH2gfTaIpW4cbpRx8uwHY52MlvXhW1lawHHZkGTwRPIILkgBVA==",
+      "requires": {
+        "@advanced-rest-client/arc-icons": "^3.0.5",
+        "@advanced-rest-client/events-target-mixin": "^3.0.0",
+        "@anypoint-web-components/anypoint-dropdown": "^1.0.1",
+        "@anypoint-web-components/anypoint-dropdown-menu": "^0.1.14",
+        "@anypoint-web-components/anypoint-input": "^0.2.14",
+        "@anypoint-web-components/anypoint-item": "^1.0.5",
+        "@anypoint-web-components/anypoint-listbox": "^1.0.4",
+        "@api-components/amf-helper-mixin": "^4.0.24",
+        "lit-element": "^2.3.1",
+        "lit-html": "^1.2.1"
       }
     },
     "@api-components/api-summary": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@anypoint-web-components/anypoint-button": "^1.0.14",
     "@api-components/amf-helper-mixin": "^4.0.24",
     "@api-components/api-console-ext-comm": "^3.0.0",
-    "@api-components/api-documentation": "^4.0.5",
+    "@api-components/api-documentation": "^4.1.0",
     "@api-components/api-navigation": "^4.1.0",
     "@api-components/api-request-panel": "^4.0.1",
     "@api-components/raml-aware": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@anypoint-web-components/anypoint-button": "^1.0.14",
     "@api-components/amf-helper-mixin": "^4.0.24",
     "@api-components/api-console-ext-comm": "^3.0.0",
-    "@api-components/api-documentation": "^4.1.0",
+    "@api-components/api-documentation": "^4.1.1",
     "@api-components/api-navigation": "^4.1.0",
     "@api-components/api-request-panel": "^4.0.1",
     "@api-components/raml-aware": "^3.0.0",

--- a/src/ApiConsole.js
+++ b/src/ApiConsole.js
@@ -293,7 +293,7 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
       baseUri,
       selectedServerValue,
       selectedServerType,
-      noDocumentationServerSelector,
+      _noDocumentationServerSelector,
       noServerSelector,
       noCustomServer
     } = this;
@@ -305,7 +305,7 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
       ?narrow="${narrow}"
       ?compatibility="${compatibility}"
       ?outlined="${outlined}"
-      ?noServerSelector="${noServerSelector || noDocumentationServerSelector}"
+      ?noServerSelector="${noServerSelector || _noDocumentationServerSelector}"
       ?noCustomServer="${noCustomServer}"
       .inlineMethods="${inlineMethods}"
       .noTryIt="${_noTryItValue}"
@@ -591,7 +591,7 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
        * Optional property to set
        * If true, forces the api-documentation to hide the server selector
        */
-      noDocumentationServerSelector: { type: Boolean },
+      _noDocumentationServerSelector: { type: Boolean },
       /**
        * Optional property to set
        * If true, the server selector custom option is not rendered

--- a/src/ApiConsole.js
+++ b/src/ApiConsole.js
@@ -293,6 +293,7 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
       baseUri,
       selectedServerValue,
       selectedServerType,
+      noDocumentationServerSelector,
       noServerSelector,
       noCustomServer
     } = this;
@@ -304,7 +305,7 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
       ?narrow="${narrow}"
       ?compatibility="${compatibility}"
       ?outlined="${outlined}"
-      ?noServerSelector="${noServerSelector}"
+      ?noServerSelector="${noServerSelector || noDocumentationServerSelector}"
       ?noCustomServer="${noCustomServer}"
       .inlineMethods="${inlineMethods}"
       .noTryIt="${_noTryItValue}"
@@ -583,9 +584,14 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
       selectedServerType: { type: String },
       /**
        * Optional property to set
-       * If true, the server selector is not rendered
+       * If true, the server selector is not rendered in any component
        */
       noServerSelector: { type: Boolean },
+      /**
+       * Optional property to set
+       * If true, forces the api-documentation to hide the server selector
+       */
+      noDocumentationServerSelector: { type: Boolean },
       /**
        * Optional property to set
        * If true, the server selector custom option is not rendered

--- a/src/ApiConsole.js
+++ b/src/ApiConsole.js
@@ -294,7 +294,9 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
       selectedServerValue,
       selectedServerType,
       noServerSelector,
+      noCustomServer
     } = this;
+
     return html`<api-documentation
       .amf="${amf}"
       .selected="${selectedShape}"
@@ -303,6 +305,7 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
       ?compatibility="${compatibility}"
       ?outlined="${outlined}"
       ?noServerSelector="${noServerSelector}"
+      ?noCustomServer="${noCustomServer}"
       .inlineMethods="${inlineMethods}"
       .noTryIt="${_noTryItValue}"
       .baseUri="${baseUri}"

--- a/src/ApiConsoleApp.js
+++ b/src/ApiConsoleApp.js
@@ -173,7 +173,7 @@ export class ApiConsoleApp extends ApiConsole {
       return;
     }
     this._wideLayout = value;
-    this.noDocumentationServerSelector = value;
+    this._noDocumentationServerSelector = value;
     this._updateRenderInlineTyit();
   }
 

--- a/src/ApiConsoleApp.js
+++ b/src/ApiConsoleApp.js
@@ -173,6 +173,7 @@ export class ApiConsoleApp extends ApiConsole {
       return;
     }
     this._wideLayout = value;
+    this.noDocumentationServerSelector = value;
     this._updateRenderInlineTyit();
   }
 


### PR DESCRIPTION
- Update api-documentation dependency
- Pass `narrow` to `api-console` in element demo, so api-documentation renders with narrow mode (@jarrodek please confirm this is desirable)
- Allow passing `noCustomServer` property to api-documentation

## Element demo
![image](https://user-images.githubusercontent.com/5473642/79782408-6b8a5080-8315-11ea-9da5-cf1d2ebf4c46.png)

## Standalone demo
![image](https://user-images.githubusercontent.com/5473642/79782463-878df200-8315-11ea-99a8-e766e1d93377.png)
