### PR TITLE
2.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api-console",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -150,11 +150,11 @@
       }
     },
     "@advanced-rest-client/events-target-mixin": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/events-target-mixin/-/events-target-mixin-3.2.2.tgz",
-      "integrity": "sha512-b8/k45Ju0+FgM8FQaShLaVJEXKLcheLNtf1PCtQRgetQOT0FO0L6mHlVHVbjH8B9uaP5qMO19ZDSjh5kW6D4uw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/events-target-mixin/-/events-target-mixin-3.2.3.tgz",
+      "integrity": "sha512-rXdou8ZqOhtb8BEp5YFJXi1i3xugIuH3k154mdcuObkd5LR/HEHdACKKaYyGe7ATmaBy5mzvr7l4WZFpiTigNg==",
       "requires": {
-        "@open-wc/dedupe-mixin": "^1.2.17"
+        "@open-wc/dedupe-mixin": "^1.2.18"
       }
     },
     "@advanced-rest-client/files-payload-editor": {
@@ -449,13 +449,38 @@
       }
     },
     "@advanced-rest-client/testing-karma-sl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/testing-karma-sl/-/testing-karma-sl-1.3.1.tgz",
-      "integrity": "sha512-yc8W+0ZRIkZL40G2x0VNFqBvKH/bgu5g3R7dKH1unTVj+rHzXBG9ZmLJuDzRNMOGVCRL4v8/ISOoaBCdDAE9fw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/testing-karma-sl/-/testing-karma-sl-1.4.1.tgz",
+      "integrity": "sha512-iba/zY3KO6YcJbPkdkO/5F6Rx5T2R3zJuOvF55KDU/QH6RS5EEI2OTU/LbwzjyiV8ty/K7NMqj4LA1wnO0z1cw==",
       "dev": true,
       "requires": {
-        "@open-wc/testing-karma": "^3.3.19",
-        "karma-sauce-launcher": "^4.1.4"
+        "@open-wc/testing-karma": "^4.0.3",
+        "karma-sauce-launcher": "^4.1.5"
+      },
+      "dependencies": {
+        "@open-wc/testing-karma": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-4.0.5.tgz",
+          "integrity": "sha512-yEllAsQkw25dorjKJ8Ry4IXi1qHqDPxEU8GdycGs5FQYtKPUQZtzMGooE/lVzmeJpvU0tT9DcAjgAU2Yob1lxA==",
+          "dev": true,
+          "requires": {
+            "@open-wc/karma-esm": "^3.0.5",
+            "@types/karma": "^5.0.0",
+            "@types/karma-coverage-istanbul-reporter": "^2.1.0",
+            "@types/karma-mocha": "^1.3.0",
+            "@types/karma-mocha-reporter": "^2.2.0",
+            "axe-core": "^3.5.3",
+            "karma": "^5.1.1",
+            "karma-chrome-launcher": "^3.1.0",
+            "karma-coverage": "^2.0.2",
+            "karma-mocha": "^1.0.0",
+            "karma-mocha-reporter": "^2.0.0",
+            "karma-mocha-snapshot": "^0.2.1",
+            "karma-snapshot": "^0.6.0",
+            "karma-source-map-support": "^1.3.0",
+            "mocha": "^6.2.2"
+          }
+        }
       }
     },
     "@advanced-rest-client/url-parser": {
@@ -531,9 +556,9 @@
       }
     },
     "@anypoint-web-components/anypoint-dropdown-menu": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-dropdown-menu/-/anypoint-dropdown-menu-0.1.16.tgz",
-      "integrity": "sha512-Fv3grmOBclW/P5XwFIb6ydpbY0UY7PRnU4Dcowr3CmWuz6NzMutYeastllqHh44w7CcogMRpxBvfxlMRYPCNeg==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-dropdown-menu/-/anypoint-dropdown-menu-0.1.17.tgz",
+      "integrity": "sha512-zuj4khwSAuDlhFd18SjZAAr9dN9RR0E2+XbCUcYSdp6CVukv1N4bLREsBozc4kU9cv6Rn5IRzJIzLeFWdfURQA==",
       "requires": {
         "@anypoint-web-components/anypoint-button": "^1.1.1",
         "@anypoint-web-components/anypoint-control-mixins": "^1.1.1",
@@ -553,15 +578,15 @@
       }
     },
     "@anypoint-web-components/anypoint-input": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-input/-/anypoint-input-0.2.17.tgz",
-      "integrity": "sha512-XL9g+r9PWdLWCznz/W3bdTJ1XHFRhOrTLXTIi+9y3OwsSyOupA87L9cFz0RWjSnwxadl/kLcfId4vQHzyGlXyg==",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-input/-/anypoint-input-0.2.20.tgz",
+      "integrity": "sha512-sexH3RU+fkzf3MLJKgwzB3RRjzVkO3l1tA/V8yvLlPIlDXmp0oESkpXZEmVsq8aQ0p6AGlRJjgmkqlhr1UJbog==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.1.0",
         "@anypoint-web-components/anypoint-button": "^1.1.1",
         "@anypoint-web-components/anypoint-control-mixins": "^1.1.1",
         "@anypoint-web-components/validatable-mixin": "^1.1.1",
-        "@open-wc/dedupe-mixin": "^1.2.17",
+        "@open-wc/dedupe-mixin": "^1.2.18",
         "lit-element": "^2.3.1",
         "lit-html": "^1.2.1"
       }
@@ -599,14 +624,14 @@
       }
     },
     "@anypoint-web-components/anypoint-radio-button": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-radio-button/-/anypoint-radio-button-0.1.4.tgz",
-      "integrity": "sha512-3mcppcK6Rk+C5px1vclg4XQzitHORvIh9tik7x6qOt0/GNwYdeJ3t3QH8kjZ4EbszPTTqoc1s1VBBLVqgwA+jQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-radio-button/-/anypoint-radio-button-0.1.5.tgz",
+      "integrity": "sha512-Ajq6HtOrw7fiHf7Etl6YcP5Ft/N1eukIZX6mPFQSLg0JtTS3xpSmVREY+NcUJNZ+4ZZ8ojU9RsX17IQ0mYiB7g==",
       "requires": {
-        "@anypoint-web-components/anypoint-form-mixins": "^1.0.1",
-        "@anypoint-web-components/anypoint-menu-mixin": "^1.0.2",
+        "@anypoint-web-components/anypoint-form-mixins": "^1.2.0",
+        "@anypoint-web-components/anypoint-menu-mixin": "^1.1.6",
         "@anypoint-web-components/anypoint-styles": "^1.0.1",
-        "lit-element": "^2.0.1"
+        "lit-element": "^2.3.1"
       }
     },
     "@anypoint-web-components/anypoint-selector": {
@@ -671,9 +696,9 @@
       }
     },
     "@api-components/amf-helper-mixin": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.1.7.tgz",
-      "integrity": "sha512-vKt6S37/0RI12zONOnBvevL7RzS4HPRaa0qdS+CVPe3bvcY6gr3XRAccmP+dPDJu/YgY7ebmVq5LX2lyTgDHow=="
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.1.8.tgz",
+      "integrity": "sha512-+j/xWUCepB7Xdv6rP4Ypwhwnax8XEMOK+mwz1iqDIDBDI4U2AT/EL3FUIKBBSjCFXelZiUd05EU/qwT95aYwIQ=="
     },
     "@api-components/api-annotation-document": {
       "version": "4.0.3",
@@ -718,9 +743,9 @@
       }
     },
     "@api-components/api-body-document": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@api-components/api-body-document/-/api-body-document-4.1.1.tgz",
-      "integrity": "sha512-LC1V5sz6LVGtBDZWmSatUS9oyEQhb8ju/BkiAPz7LiQTYPz/oW5gdUHk/Czh/GRcIinRfiLUeJX8P6mAaln0OQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@api-components/api-body-document/-/api-body-document-4.1.2.tgz",
+      "integrity": "sha512-d6wpNTWp6xLPBeZ3d5ea8sqiy69AnMurDfV7/j6S61JvO/IPo+0DQhE7l1e6nqV2TbcNE8Nt3kBv8J+FvwjapQ==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.0.4",
         "@advanced-rest-client/arc-marked": "^1.0.6",
@@ -823,9 +848,9 @@
       }
     },
     "@api-components/api-example-generator": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@api-components/api-example-generator/-/api-example-generator-4.4.1.tgz",
-      "integrity": "sha512-sRAPzGqHRSD74OBOZVixVaUqJA46vRAf6JcAlIMLv+4l7D0DCX+ArCKUt/ltlWC24/VpKkxrVW7pkjlCS66XQQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@api-components/api-example-generator/-/api-example-generator-4.4.2.tgz",
+      "integrity": "sha512-Y6LXdOV9jPbZVMoTueqmjsohlk7+xyQdiIIth0t/hKi/P8Kjl2c6Zv3AXAcsmX8Yvttgbf/MdDk/RL6wGmAanw==",
       "requires": {
         "@api-components/amf-helper-mixin": "^4.1.1",
         "lit-element": "^2.3.1"
@@ -897,9 +922,9 @@
       }
     },
     "@api-components/api-method-documentation": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-method-documentation/-/api-method-documentation-5.0.0.tgz",
-      "integrity": "sha512-gumkL5gndKRmY0qiRHnUqTeG8p+Mqez1Y1eNKxc7oKIZ/AVI/PDr79Ocj5YNkXMK4pWGoYx00h0jMLNYZzaL6A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@api-components/api-method-documentation/-/api-method-documentation-5.0.1.tgz",
+      "integrity": "sha512-DxsXbQj4ulqmMRkMwlOQTlt509vz6wyRDFZY0EiCpTzxHuSSDPIA1FCBsMyZoWlCa1Gedvd1KP34CPHN2C0m2w==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.0.5",
         "@advanced-rest-client/arc-marked": "^1.0.6",
@@ -946,9 +971,9 @@
       }
     },
     "@api-components/api-navigation": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@api-components/api-navigation/-/api-navigation-4.1.2.tgz",
-      "integrity": "sha512-paQ1lHbOgvzLIXNVv1wW2hGFis1uDsb4ACKjBqw6RCRthyL5+pRyRfPC02JgsNz+2jWPFH/GXhb0uF/buC0/fg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@api-components/api-navigation/-/api-navigation-4.1.4.tgz",
+      "integrity": "sha512-J6Szt0r8L2D87LnLFA5KPKG5VKHkgp/xBVfzvPid6dXs1jUPC9+GB+rMY8/eNsCZfk0oGa2DEwoTNsWl2LaV+g==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.1.0",
         "@anypoint-web-components/anypoint-button": "^1.1.1",
@@ -1037,9 +1062,9 @@
       }
     },
     "@api-components/api-resource-example-document": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-resource-example-document/-/api-resource-example-document-4.1.0.tgz",
-      "integrity": "sha512-6OK09ogGQIZsD5wT+4QxVJg1RCbq3daKxmYDZ3awZLybKROjVygLDMSjyZ7dD5c1ZGlvPBOV5O74OjfMd+qbSQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@api-components/api-resource-example-document/-/api-resource-example-document-4.1.1.tgz",
+      "integrity": "sha512-p8Zka9c64/kktsB5Q2DTgiedvdyX/4N7GSyszkca20B/d08jScohBbVF0joVyZnVkwkkZaQkJUdFHLH5dd+WXQ==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.0.5",
         "@advanced-rest-client/clipboard-copy": "^3.0.1",
@@ -1210,9 +1235,9 @@
       }
     },
     "@api-components/api-view-model-transformer": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@api-components/api-view-model-transformer/-/api-view-model-transformer-4.1.1.tgz",
-      "integrity": "sha512-cb5CCka8M5m3eaXSBeRFFLEwCQYmp28c4/mPFP/cQ4wqZxk9IPfGpSHh6z52TIC//WkDmp7097fnMFy27EBSUQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@api-components/api-view-model-transformer/-/api-view-model-transformer-4.2.0.tgz",
+      "integrity": "sha512-bIwOHJmZvASqMs7Wwg0XGxii3xfGs5dJBC5emBtIELnRhon9stM24cqYc5h1Z/QyV1Xi8EfNgIwbEaX7+HtZnQ==",
       "requires": {
         "@advanced-rest-client/events-target-mixin": "^3.0.0",
         "@api-components/amf-helper-mixin": "^4.1.1",
@@ -1244,9 +1269,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.5.tgz",
-      "integrity": "sha512-mPVoWNzIpYJHbWje0if7Ck36bpbtTvIxOi9+6WSK9wjGEXearAqlwBoTQvVjsAY2VIwgcs8V940geY3okzRCEw==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
+      "integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
       "dev": true,
       "requires": {
         "browserslist": "^4.12.0",
@@ -1263,19 +1288,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-      "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.4.tgz",
+      "integrity": "sha512-5deljj5HlqRXN+5oJTY7Zs37iH3z3b++KjiKtIsJy1NrjOOVSEaJHEetLBhyu0aQOSNNZ/0IuEAan9GzRuDXHg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.10.5",
-        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/generator": "^7.11.4",
+        "@babel/helper-module-transforms": "^7.11.0",
         "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.10.5",
+        "@babel/parser": "^7.11.4",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.5",
-        "@babel/types": "^7.10.5",
+        "@babel/traverse": "^7.11.0",
+        "@babel/types": "^7.11.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -1304,12 +1329,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-      "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
+      "integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.5",
+        "@babel/types": "^7.11.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -1391,12 +1416,11 @@
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
-      "integrity": "sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
+      "integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.10.4",
         "@babel/types": "^7.10.4"
       }
     },
@@ -1430,12 +1454,12 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-      "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+      "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.5"
+        "@babel/types": "^7.11.0"
       }
     },
     "@babel/helper-module-imports": {
@@ -1448,17 +1472,17 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-      "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+      "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
         "@babel/helper-replace-supers": "^7.10.4",
         "@babel/helper-simple-access": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
         "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.5",
+        "@babel/types": "^7.11.0",
         "lodash": "^4.17.19"
       }
     },
@@ -1487,15 +1511,14 @@
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
-      "integrity": "sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
+      "integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-wrap-function": "^7.10.4",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
         "@babel/types": "^7.10.4"
       }
     },
@@ -1521,13 +1544,22 @@
         "@babel/types": "^7.10.4"
       }
     },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-      "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
+      "integrity": "sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -1593,9 +1625,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-      "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
+      "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -1629,6 +1661,16 @@
         "@babel/plugin-syntax-dynamic-import": "^7.8.0"
       }
     },
+    "@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.10.4.tgz",
+      "integrity": "sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      }
+    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
@@ -1637,6 +1679,16 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-json-strings": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-logical-assignment-operators": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.11.0.tgz",
+      "integrity": "sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
@@ -1660,9 +1712,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
-      "integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
+      "integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
@@ -1681,12 +1733,13 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.4.tgz",
-      "integrity": "sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
+      "integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.0"
       }
     },
@@ -1737,6 +1790,15 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -1753,6 +1815,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -1839,9 +1910,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz",
-      "integrity": "sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==",
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
+      "integrity": "sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -2058,9 +2129,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.5.tgz",
-      "integrity": "sha512-tV4V/FjElJ9lQtyjr5xD2IFFbgY46r7EeVu5a8CpEKT5laheHKSlFeHjpkPppW3PqzGLAuv5k2qZX5LgVZIX5w==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
+      "integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
@@ -2087,12 +2158,13 @@
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.4.tgz",
-      "integrity": "sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
+      "integrity": "sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -2144,30 +2216,34 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.4.tgz",
-      "integrity": "sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
+      "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.10.4",
+        "@babel/compat-data": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.10.4",
         "@babel/helper-module-imports": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
         "@babel/plugin-proposal-class-properties": "^7.10.4",
         "@babel/plugin-proposal-dynamic-import": "^7.10.4",
+        "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
         "@babel/plugin-proposal-json-strings": "^7.10.4",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
         "@babel/plugin-proposal-numeric-separator": "^7.10.4",
-        "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
         "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-        "@babel/plugin-proposal-optional-chaining": "^7.10.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.11.0",
         "@babel/plugin-proposal-private-methods": "^7.10.4",
         "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
         "@babel/plugin-syntax-async-generators": "^7.8.0",
         "@babel/plugin-syntax-class-properties": "^7.10.4",
         "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
         "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
@@ -2200,14 +2276,14 @@
         "@babel/plugin-transform-regenerator": "^7.10.4",
         "@babel/plugin-transform-reserved-words": "^7.10.4",
         "@babel/plugin-transform-shorthand-properties": "^7.10.4",
-        "@babel/plugin-transform-spread": "^7.10.4",
+        "@babel/plugin-transform-spread": "^7.11.0",
         "@babel/plugin-transform-sticky-regex": "^7.10.4",
         "@babel/plugin-transform-template-literals": "^7.10.4",
         "@babel/plugin-transform-typeof-symbol": "^7.10.4",
         "@babel/plugin-transform-unicode-escapes": "^7.10.4",
         "@babel/plugin-transform-unicode-regex": "^7.10.4",
         "@babel/preset-modules": "^0.1.3",
-        "@babel/types": "^7.10.4",
+        "@babel/types": "^7.11.0",
         "browserslist": "^4.12.0",
         "core-js-compat": "^3.6.2",
         "invariant": "^2.2.2",
@@ -2224,9 +2300,9 @@
       }
     },
     "@babel/preset-modules": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
-      "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+      "integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -2237,9 +2313,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
-      "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -2257,26 +2333,26 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-      "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+      "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.10.5",
+        "@babel/generator": "^7.11.0",
         "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.10.4",
-        "@babel/parser": "^7.10.5",
-        "@babel/types": "^7.10.5",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.11.0",
+        "@babel/types": "^7.11.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       }
     },
     "@babel/types": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-      "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+      "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -2775,6 +2851,1248 @@
         }
       }
     },
+    "@comunica/actor-abstract-bindings-hash": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.16.0.tgz",
+      "integrity": "sha512-W7oU8J0n6wC8R8EQ7UEvdmaJXf/Z3gEVCw9H+WXJSTEg1B77nrHuQs1lJreteKCIJEhC7BQYLtrfKE5N92edKw==",
+      "dev": true,
+      "requires": {
+        "canonicalize": "^1.0.1",
+        "rdf-string": "^1.4.2"
+      }
+    },
+    "@comunica/actor-abstract-mediatyped": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.15.0.tgz",
+      "integrity": "sha512-rB0DnIuiZKGqAd6JmcXdajmgDPWzffqCqLyAp2A967NRN1NlPbPnfwkCJBHVehdcyT69dAaEkHoHDZpbwOVjHg==",
+      "dev": true
+    },
+    "@comunica/actor-abstract-path": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.16.0.tgz",
+      "integrity": "sha512-a53X/a9DTl6rYNbBGXCmUY9crusU6ySAiRZY3usiPWzqHeiZonM5+eRKzYm8vazxg3hLBs8jowKiZhiUPrx4wQ==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "rdf-string": "^1.4.2",
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-http-memento": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.16.0.tgz",
+      "integrity": "sha512-X58EUsxFch+/VoS58Ld1yFsSNjeu7xYtvPV6x4IpGv16V+QJot4KyKH25+SAwNOQDiRxShX55FovCCVvSxK35w==",
+      "dev": true,
+      "requires": {
+        "@types/parse-link-header": "^1.0.0",
+        "cross-fetch": "^3.0.5",
+        "parse-link-header": "^1.0.1"
+      }
+    },
+    "@comunica/actor-http-native": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.16.2.tgz",
+      "integrity": "sha512-KhmYTKOmf4QZwd8CVy4f4o6d/LVzBy19JmpOIP1vLcOTAVOXg6KXDT+NEVSoDIc9T5fpKDh91bWuukptUqVjig==",
+      "dev": true,
+      "requires": {
+        "@types/parse-link-header": "^1.0.0",
+        "cross-fetch": "^3.0.5",
+        "follow-redirects": "^1.5.1",
+        "parse-link-header": "^1.0.1"
+      }
+    },
+    "@comunica/actor-http-proxy": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.16.0.tgz",
+      "integrity": "sha512-5aD5y9b6DvcCX2/ud/aVvUjvipppMmzKRV3C0evbA3NoAZ4VF8ejD+JpIjDsrvrbWeXVPueXvL/yfssUz17iIg==",
+      "dev": true
+    },
+    "@comunica/actor-init-sparql": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.16.2.tgz",
+      "integrity": "sha512-jzE/sW1ciNXtO/tRYEhSiKFxpB9/cqPME9a2jq/GYq9PmTv5MzcUbZEY7x8QRkRQ3Dp0Z2JHI/sorps8LPwcmQ==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.16.0",
+        "@comunica/actor-abstract-mediatyped": "^1.15.0",
+        "@comunica/actor-http-memento": "^1.16.0",
+        "@comunica/actor-http-native": "^1.16.2",
+        "@comunica/actor-http-proxy": "^1.16.0",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^1.16.0",
+        "@comunica/actor-query-operation-ask": "^1.16.0",
+        "@comunica/actor-query-operation-bgp-empty": "^1.16.0",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.16.0",
+        "@comunica/actor-query-operation-bgp-single": "^1.16.0",
+        "@comunica/actor-query-operation-construct": "^1.16.0",
+        "@comunica/actor-query-operation-describe-subject": "^1.16.0",
+        "@comunica/actor-query-operation-distinct-hash": "^1.16.0",
+        "@comunica/actor-query-operation-extend": "^1.16.0",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.16.0",
+        "@comunica/actor-query-operation-from-quad": "^1.16.0",
+        "@comunica/actor-query-operation-group": "^1.16.0",
+        "@comunica/actor-query-operation-join": "^1.16.0",
+        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.16.0",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.16.0",
+        "@comunica/actor-query-operation-minus": "^1.16.0",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.16.0",
+        "@comunica/actor-query-operation-path-alt": "^1.16.0",
+        "@comunica/actor-query-operation-path-inv": "^1.16.0",
+        "@comunica/actor-query-operation-path-link": "^1.16.0",
+        "@comunica/actor-query-operation-path-nps": "^1.16.0",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.16.0",
+        "@comunica/actor-query-operation-path-seq": "^1.16.0",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.16.0",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.16.0",
+        "@comunica/actor-query-operation-project": "^1.16.0",
+        "@comunica/actor-query-operation-quadpattern": "^1.16.0",
+        "@comunica/actor-query-operation-reduced-hash": "^1.16.0",
+        "@comunica/actor-query-operation-service": "^1.16.0",
+        "@comunica/actor-query-operation-slice": "^1.16.0",
+        "@comunica/actor-query-operation-sparql-endpoint": "^1.16.0",
+        "@comunica/actor-query-operation-union": "^1.16.0",
+        "@comunica/actor-query-operation-values": "^1.16.0",
+        "@comunica/actor-rdf-dereference-http-parse": "^1.16.0",
+        "@comunica/actor-rdf-join-multi-smallest": "^1.16.0",
+        "@comunica/actor-rdf-join-nestedloop": "^1.16.0",
+        "@comunica/actor-rdf-join-symmetrichash": "^1.16.0",
+        "@comunica/actor-rdf-metadata-all": "^1.15.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.15.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.15.0",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.15.0",
+        "@comunica/actor-rdf-metadata-primary-topic": "^1.15.0",
+        "@comunica/actor-rdf-parse-html": "^1.15.0",
+        "@comunica/actor-rdf-parse-html-rdfa": "^1.15.0",
+        "@comunica/actor-rdf-parse-html-script": "^1.16.1",
+        "@comunica/actor-rdf-parse-jsonld": "^1.16.0",
+        "@comunica/actor-rdf-parse-n3": "^1.15.0",
+        "@comunica/actor-rdf-parse-rdfxml": "^1.15.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^1.15.0",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.15.0",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.15.0",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.16.0",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.16.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.16.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.16.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.16.0",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.15.0",
+        "@comunica/actor-rdf-serialize-n3": "^1.15.0",
+        "@comunica/actor-sparql-parse-algebra": "^1.16.0",
+        "@comunica/actor-sparql-parse-graphql": "^1.15.0",
+        "@comunica/actor-sparql-serialize-json": "^1.16.0",
+        "@comunica/actor-sparql-serialize-rdf": "^1.16.0",
+        "@comunica/actor-sparql-serialize-simple": "^1.16.0",
+        "@comunica/actor-sparql-serialize-sparql-csv": "^1.16.0",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.16.0",
+        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.16.0",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.16.0",
+        "@comunica/actor-sparql-serialize-stats": "^1.16.0",
+        "@comunica/actor-sparql-serialize-table": "^1.16.0",
+        "@comunica/actor-sparql-serialize-tree": "^1.16.0",
+        "@comunica/bus-context-preprocess": "^1.15.0",
+        "@comunica/bus-http": "^1.16.0",
+        "@comunica/bus-http-invalidate": "^1.15.0",
+        "@comunica/bus-init": "^1.15.0",
+        "@comunica/bus-optimize-query-operation": "^1.16.0",
+        "@comunica/bus-query-operation": "^1.16.0",
+        "@comunica/bus-rdf-dereference": "^1.15.0",
+        "@comunica/bus-rdf-dereference-paged": "^1.15.0",
+        "@comunica/bus-rdf-join": "^1.16.0",
+        "@comunica/bus-rdf-metadata": "^1.15.0",
+        "@comunica/bus-rdf-metadata-extract": "^1.15.0",
+        "@comunica/bus-rdf-parse": "^1.15.0",
+        "@comunica/bus-rdf-parse-html": "^1.15.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^1.15.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.15.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.16.0",
+        "@comunica/bus-rdf-serialize": "^1.15.0",
+        "@comunica/bus-sparql-parse": "^1.15.0",
+        "@comunica/bus-sparql-serialize": "^1.16.0",
+        "@comunica/core": "^1.15.0",
+        "@comunica/logger-pretty": "^1.15.0",
+        "@comunica/logger-void": "^1.15.0",
+        "@comunica/mediator-all": "^1.15.0",
+        "@comunica/mediator-combine-pipeline": "^1.15.0",
+        "@comunica/mediator-combine-union": "^1.15.0",
+        "@comunica/mediator-number": "^1.15.0",
+        "@comunica/mediator-race": "^1.15.0",
+        "@comunica/runner": "^1.16.0",
+        "@comunica/runner-cli": "^1.16.0",
+        "@types/minimist": "^1.2.0",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "asyncreiterable": "^2.0.0",
+        "minimist": "^1.2.0",
+        "negotiate": "^1.0.1",
+        "rdf-quad": "^1.4.0",
+        "rdf-string": "^1.4.2",
+        "rdf-terms": "^1.4.0",
+        "streamify-string": "^1.0.1"
+      }
+    },
+    "@comunica/actor-init-sparql-rdfjs": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.16.2.tgz",
+      "integrity": "sha512-37FizXW2XCtyRFq0vjCqTAzxnVVklYGoq3Rmn6sBelF6wKW7pqtHunBA3yOJfo5MKRVoFD04wHCbwaWC6xaYEw==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^1.15.0",
+        "@comunica/actor-init-sparql": "^1.16.2",
+        "@comunica/actor-query-operation-ask": "^1.16.0",
+        "@comunica/actor-query-operation-bgp-empty": "^1.16.0",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.16.0",
+        "@comunica/actor-query-operation-bgp-single": "^1.16.0",
+        "@comunica/actor-query-operation-construct": "^1.16.0",
+        "@comunica/actor-query-operation-describe-subject": "^1.16.0",
+        "@comunica/actor-query-operation-distinct-hash": "^1.16.0",
+        "@comunica/actor-query-operation-extend": "^1.16.0",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.16.0",
+        "@comunica/actor-query-operation-from-quad": "^1.16.0",
+        "@comunica/actor-query-operation-join": "^1.16.0",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.16.0",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.16.0",
+        "@comunica/actor-query-operation-path-alt": "^1.16.0",
+        "@comunica/actor-query-operation-path-inv": "^1.16.0",
+        "@comunica/actor-query-operation-path-link": "^1.16.0",
+        "@comunica/actor-query-operation-path-nps": "^1.16.0",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.16.0",
+        "@comunica/actor-query-operation-path-seq": "^1.16.0",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.16.0",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.16.0",
+        "@comunica/actor-query-operation-project": "^1.16.0",
+        "@comunica/actor-query-operation-quadpattern": "^1.16.0",
+        "@comunica/actor-query-operation-service": "^1.16.0",
+        "@comunica/actor-query-operation-slice": "^1.16.0",
+        "@comunica/actor-query-operation-union": "^1.16.0",
+        "@comunica/actor-query-operation-values": "^1.16.0",
+        "@comunica/actor-rdf-join-nestedloop": "^1.16.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.16.0",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.15.0",
+        "@comunica/actor-rdf-serialize-n3": "^1.15.0",
+        "@comunica/actor-sparql-parse-algebra": "^1.16.0",
+        "@comunica/actor-sparql-serialize-json": "^1.16.0",
+        "@comunica/actor-sparql-serialize-rdf": "^1.16.0",
+        "@comunica/actor-sparql-serialize-simple": "^1.16.0",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.16.0",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.16.0",
+        "@comunica/bus-context-preprocess": "^1.15.0",
+        "@comunica/bus-init": "^1.15.0",
+        "@comunica/bus-query-operation": "^1.16.0",
+        "@comunica/bus-rdf-join": "^1.16.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.16.0",
+        "@comunica/bus-rdf-serialize": "^1.15.0",
+        "@comunica/bus-sparql-parse": "^1.15.0",
+        "@comunica/bus-sparql-serialize": "^1.16.0",
+        "@comunica/core": "^1.15.0",
+        "@comunica/mediator-combine-pipeline": "^1.15.0",
+        "@comunica/mediator-combine-union": "^1.15.0",
+        "@comunica/mediator-number": "^1.15.0",
+        "@comunica/mediator-race": "^1.15.0",
+        "@comunica/runner": "^1.16.0",
+        "@comunica/runner-cli": "^1.16.0"
+      }
+    },
+    "@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.16.0.tgz",
+      "integrity": "sha512-KWuAKG8S+IwonyecNjqrO5dlSKSVmR1cxP117/DEUPIltXl0IY2W3Q/HKRRZ+DXwV/LRMExIXILdUkZgYUSnAw==",
+      "dev": true,
+      "requires": {
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-query-operation-ask": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.16.0.tgz",
+      "integrity": "sha512-zlWYPh7GoIw7epzcORfDWwRFsfLciJGVSaCR2C46AZj8CctApf+mzrRDY7H3WSETyTc6s9T1fiDzGjBY/P3TbA==",
+      "dev": true
+    },
+    "@comunica/actor-query-operation-bgp-empty": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.16.0.tgz",
+      "integrity": "sha512-C8q0YKNcIbMZ1KWL1juCoTbppYQcI3/0qlp/boBD1w8yeNVt2ytxB0cKsdVilvLVVcooISJJKNn4j8uGqOJsZg==",
+      "dev": true,
+      "requires": {
+        "asynciterator": "^3.0.1",
+        "rdf-string": "^1.4.2",
+        "rdf-terms": "^1.4.0"
+      }
+    },
+    "@comunica/actor-query-operation-bgp-left-deep-smallest": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.16.0.tgz",
+      "integrity": "sha512-8zB8ajT7z6nYDge9//7zP0sziKmnCFLVVtqqyacSQ8Yu9jl15b42rqMiZ0ty9c3qZncH2DagqiTd/5VCJP3nMg==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "rdf-string": "^1.4.2",
+        "rdf-terms": "^1.4.0"
+      }
+    },
+    "@comunica/actor-query-operation-bgp-single": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.16.0.tgz",
+      "integrity": "sha512-nUcGlq9uJCl5O7rGnFCrFeHrWSRD7hZW9QU+B7tCoSbJoUrKS9hBKkDO6xUHmsmztRKfzHgMO9LFDvmc5jGKlQ==",
+      "dev": true
+    },
+    "@comunica/actor-query-operation-construct": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.16.0.tgz",
+      "integrity": "sha512-c4tLLcl7T1JYCg790LEu9Ijn3c7i2yd2uKJ9E2oytx6KLeW0YQeEaiLZ1hn3XDlQHMvfYeGznd4Y+X8632+Faw==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "rdf-terms": "^1.4.0"
+      }
+    },
+    "@comunica/actor-query-operation-describe-subject": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.16.0.tgz",
+      "integrity": "sha512-F5x0AU/7K9Zw6o5/y2AWsX5G3YPyLoDekWm1bHyztnHD21WFGsOgAt7R3XOJLU4/d9Mc2TpDOj17bttplJRXSg==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-query-operation-union": "^1.16.0",
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1"
+      }
+    },
+    "@comunica/actor-query-operation-distinct-hash": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.16.0.tgz",
+      "integrity": "sha512-/SKXl7lFUlJ83yL81lD3RyzqkV5ONqUiqR8d1D0Vob/m8DI7ynDp8f5x74ocBLdrhFADJvGlVl8703AjJzcD6w==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.16.0"
+      }
+    },
+    "@comunica/actor-query-operation-extend": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.16.0.tgz",
+      "integrity": "sha512-xad5NhPZ4KJsk3DTlG6mb0ZEX6LccCRjhFEVZsNT4qr1DPTqD5MaeE/SfjFADCwDniy5gZTxn6AQnQ1LsC52Eg==",
+      "dev": true,
+      "requires": {
+        "sparqlee": "^1.4.3"
+      }
+    },
+    "@comunica/actor-query-operation-filter-sparqlee": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.16.0.tgz",
+      "integrity": "sha512-96ttlUQkBpkiUlXnClvjEaYHtEL8gCVzhOMcMLxuOAifwgv7I6Qe5WQT8QZkJbXbbwNvelXYC4Cs37p85nHSCw==",
+      "dev": true,
+      "requires": {
+        "sparqlee": "^1.4.3"
+      }
+    },
+    "@comunica/actor-query-operation-from-quad": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.16.0.tgz",
+      "integrity": "sha512-qyjSrxmi0WSlxMbZo2djOfUD+2Jkm7s4JOW36ua8JBbSuGAbHwFI3xYSWiWYmLCMQEp3YgqHrTKWeGDSnqxnJQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-query-operation-group": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.16.0.tgz",
+      "integrity": "sha512-xwmoNsfjcsS04s3lLlf6dua81ywFNqOU77g61tZEveCAKyC5fN6rQZM8eLBa87z7HhHLHF42V1TVXh3PD46HaA==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.16.0",
+        "rdf-string": "^1.4.2",
+        "sparqlee": "^1.4.3"
+      }
+    },
+    "@comunica/actor-query-operation-join": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.16.0.tgz",
+      "integrity": "sha512-3lJt1dTrBm4ogRwCyEPwqOrJ/QfEEYu5tHUClpiP3vG0L1tmN+wRfewAxU7P8o0Rec0QkqICAMRf252tM0ftgw==",
+      "dev": true
+    },
+    "@comunica/actor-query-operation-leftjoin-left-deep": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.16.0.tgz",
+      "integrity": "sha512-fVVdcMEFvQpU8eKQyDys7q6jL6SosHdSs2j5ARPmXvY/hzl68coIb4D0JmMIIWmk87TDcc9VUH0mcnHI5f7Eqw==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1"
+      }
+    },
+    "@comunica/actor-query-operation-leftjoin-nestedloop": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.16.0.tgz",
+      "integrity": "sha512-dTNcGe4LTwgJcvAV2TZA9lF6gmvtcQDFm+4UEiY5ehtgOD/Quh39AixYSXTNOsmMmGBamr5iBfk1ABgRwAmzyg==",
+      "dev": true,
+      "requires": {
+        "sparqlee": "^1.4.3"
+      }
+    },
+    "@comunica/actor-query-operation-minus": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.16.0.tgz",
+      "integrity": "sha512-PeM5FouB+BJMU2QYB//SK9O5LCdielQnrr+nTWXyznrx1kpBqMX7Elzmim5huhKY3Y0WfotL6rGsE5DEjdRE1w==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.16.0",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1"
+      }
+    },
+    "@comunica/actor-query-operation-orderby-sparqlee": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.16.0.tgz",
+      "integrity": "sha512-mRubrkxjevfsrr3sMn/scVg9pveNDLammx5jtrBDm5IKkL2muTH6HGduLCmT/zONBkxUZy2uOiXQgxHXrtznsw==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "rdf-string": "^1.4.2",
+        "sparqlee": "^1.4.3"
+      }
+    },
+    "@comunica/actor-query-operation-path-alt": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.16.0.tgz",
+      "integrity": "sha512-VJiGYoupy41Rcbbf4BymERWC5U7OjVtSe0JuSkHoOmKl9HcXQo+dGur+XJpbKz391rDY+BB2djH3Bht1YmrYig==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.16.0",
+        "asynciterator": "^3.0.1",
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-query-operation-path-inv": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.16.0.tgz",
+      "integrity": "sha512-xVWLGiaIbuv2vudAFVgotHx/YCNQ+deflpgSyg5RsUU7cnqj3njkt4Iq8lX+8Sdwjmr10UIAqXPVMHKsRCRKzA==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.16.0"
+      }
+    },
+    "@comunica/actor-query-operation-path-link": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.16.0.tgz",
+      "integrity": "sha512-YCPgTQGfQCtp88OneFYTyXBG9pHuHs5Plfmj3BZP0fhbIXhn6ywn4LP5NXaVukJFCDwCFRWL9Pd1aZ5N0p9tNQ==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.16.0",
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-query-operation-path-nps": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.16.0.tgz",
+      "integrity": "sha512-S/CDgtnLQC+3qndBOST1y+AvUsCc/nh08+4s91K9RqkuQwV5/1Sl5B0aThMItazTKuUPj04ujH+PCOArt1+sbQ==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.16.0",
+        "rdf-string": "^1.4.2",
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-query-operation-path-one-or-more": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.16.0.tgz",
+      "integrity": "sha512-RpjvSeua4hsSISonfK53qMlWizQ9ou208zpiGpGLamDAVpLj4pgKAQ3ksfWM+GR2sXVDiCIAvpszJkSEa9NY/w==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.16.0",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "rdf-string": "^1.4.2",
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-query-operation-path-seq": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.16.0.tgz",
+      "integrity": "sha512-/vbN8Y8a+Sb1XcP796YxwahiD2b3euxHBu1h4pLu0oTKg6KTqbjHjbGQhxe95sWU3HKoH7F7VErTjlX8Wl29Kw==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.16.0",
+        "rdf-string": "^1.4.2",
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-query-operation-path-zero-or-more": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.16.0.tgz",
+      "integrity": "sha512-Z5NhpB4MEZHk3yhInOHILWiNzK+ZGWr+HvjYD5PtDHtbWWgE3nrxbuNhdXs1iXgaJsZWlp7ziE+H3ms4GcYjUQ==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.16.0",
+        "rdf-string": "^1.4.2",
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-query-operation-path-zero-or-one": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.16.0.tgz",
+      "integrity": "sha512-pGzrXcXsm6l0RKF9SfC8njqw72XiOns/chiuKegChqTQd00DubTJVHmfb2HUuNyiNVJ2BrjwYdAysP1gI93D5w==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.16.0",
+        "asynciterator": "^3.0.1",
+        "rdf-string": "^1.4.2"
+      }
+    },
+    "@comunica/actor-query-operation-project": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.16.0.tgz",
+      "integrity": "sha512-uTi+GmB04RnZ7Sw3XJst8tmPtiqLmT1Z4+zTspTgnWwndeWzdw7w7v6apCZDoivvPLi1Jq/7hGNn6+3FsIGp+A==",
+      "dev": true,
+      "requires": {
+        "@comunica/data-factory": "^1.14.0",
+        "rdf-string": "^1.4.2"
+      }
+    },
+    "@comunica/actor-query-operation-quadpattern": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.16.0.tgz",
+      "integrity": "sha512-QFml3MgYd5nmnsPHoDvOcx/StY+4L0ix5C1q5h8jagwIbcuRSfo1Ay0gLMlbEDuZkzrHhkN9o6OsSMTVuXsiEQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "rdf-string": "^1.4.2",
+        "rdf-terms": "^1.4.0"
+      }
+    },
+    "@comunica/actor-query-operation-reduced-hash": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.16.0.tgz",
+      "integrity": "sha512-zE1K+d6HBhGsvQQd/XGYUgpue/aSKeHbdB2r+yzEels0ShPYxogVV69aHQAUxPXvz+kbPEzqwTWz5a28lJW+cw==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.16.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@comunica/actor-query-operation-service": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.16.0.tgz",
+      "integrity": "sha512-UTWmUZa59o6DaPqHjtFM8CES3/vlis6psAW5Wt4Bw+5sgK2XZ1EWFNM/BbQG5m0OetzgDJS+BRVbsJNDGdHRdw==",
+      "dev": true,
+      "requires": {
+        "asynciterator": "^3.0.1"
+      }
+    },
+    "@comunica/actor-query-operation-slice": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.16.0.tgz",
+      "integrity": "sha512-vFo1HVlz+0Jz2a8ppPU4tXPbSL/G9TILPSyvSJjXpQpvOQRih7m9AFeXUjGtJ6sFo5SryAkgynfk6jO0Co9tzw==",
+      "dev": true
+    },
+    "@comunica/actor-query-operation-sparql-endpoint": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.16.0.tgz",
+      "integrity": "sha512-3VxGRHjwWBP23ezSKVgFJG5/nj5pMhX++8d3w3WFCC5kss+p7Qnq9P06sz/42Ya/hY/CGJM4iramadGOTnbEmw==",
+      "dev": true,
+      "requires": {
+        "@comunica/utils-datasource": "^1.16.0",
+        "@types/rdf-js": "^3.0.0",
+        "arrayify-stream": "^1.0.0",
+        "asynciterator": "^3.0.1",
+        "fetch-sparql-endpoint": "^1.6.0",
+        "rdf-string": "^1.4.2",
+        "rdf-terms": "^1.4.0",
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-query-operation-union": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.16.0.tgz",
+      "integrity": "sha512-x3eZA7T004Pdf+rEMj5ts7qs66+FFBddKnWdT10fRDkXoRTTStoSsw2oW/fk8Il9FcEAQVtNXur7ehVvzV5S5A==",
+      "dev": true,
+      "requires": {
+        "asynciterator": "^3.0.1"
+      }
+    },
+    "@comunica/actor-query-operation-values": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.16.0.tgz",
+      "integrity": "sha512-X2KE3DNiKtK1sjLkakDgfTZs2paMgNu54zp6wAlIWzg5QVj+iDk+XM5wx8JFI+Mrro4oRN9Gl9TOjGupNjLnxQ==",
+      "dev": true,
+      "requires": {
+        "asynciterator": "^3.0.1",
+        "rdf-string": "^1.4.2"
+      }
+    },
+    "@comunica/actor-rdf-dereference-http-parse": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.16.0.tgz",
+      "integrity": "sha512-IKSw5jjQLIDkbd7eX3Sw0oMuPBujQ4JX6UMpDA846T4lOZcUBTovp0PPKL4zyUd88Ea9a84Qn6uREOWed4nKvg==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.5",
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-join-multi-smallest": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.16.0.tgz",
+      "integrity": "sha512-03oN4MqKBP0eVtMPyJT/PrYR7znDXU37E6sHqW/VGqws5A+myz4G/mxSSOjVE6csN5bt2wNrfpzv9J7hjmHyVA==",
+      "dev": true
+    },
+    "@comunica/actor-rdf-join-nestedloop": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.16.0.tgz",
+      "integrity": "sha512-f+2x4hgMGWkIroGc9ld3o/dFKZIgvV5DVRI9AGsJR+AZaDmet7nydKs8fw/6nEjMfYIvuNlGVgmSEsLgsAa7sA==",
+      "dev": true,
+      "requires": {
+        "asyncjoin": "^1.0.1"
+      }
+    },
+    "@comunica/actor-rdf-join-symmetrichash": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.16.0.tgz",
+      "integrity": "sha512-d1Sszprnc+aJQt1cjycroGAkhAa2fMyECelcJGqwKWpVAXT/nsbOB0Ixb0eKTF4uGlYFrdA/OSG7frwdAORepg==",
+      "dev": true,
+      "requires": {
+        "asyncjoin": "^1.0.1"
+      }
+    },
+    "@comunica/actor-rdf-metadata-all": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.15.0.tgz",
+      "integrity": "sha512-Ax+q0igPmDQeriFL4hDMQWQPV4tsTzyboqnuXqj9U84YXmJ3y+5a5Wh/35odR3W31SwMrs56jYNIpZBKwx0+RA==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-hydra-controls": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.15.0.tgz",
+      "integrity": "sha512-Ih5OJQGfmJe5ihMeFwtWhWKSCxLXEKID3i3NGm8MgiFFbEzLAAf1YLLIK57cW88vahY+3YkPZ7tq3FeIeAi3tw==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "@types/uritemplate": "^0.3.4",
+        "uritemplate": "0.3.4"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-hydra-count": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.15.0.tgz",
+      "integrity": "sha512-3qNJWsSo0xR8xt7MEFD7rVlQXiBTLddzUK/5lX1A4dB3jk20a+c62WltctWYiIFtyCs0qYluAJ8xuJ2ItOlP7w==",
+      "dev": true
+    },
+    "@comunica/actor-rdf-metadata-extract-sparql-service": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.15.0.tgz",
+      "integrity": "sha512-CCikTWHa8nNUfmDHPGjgTH60XGcOJtkckzZXdk6kG4rMKXocsj86/cwzYM89P58LOMKy4IFfsSpoEqKIhn2gog==",
+      "dev": true,
+      "requires": {
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-metadata-primary-topic": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.15.0.tgz",
+      "integrity": "sha512-7YRtw2us52nXYcaPyk8q/rCopioCS5LEVDEteD3RqCd7KMVhg+VZYU0iD5cMF9tyYr8NoXdm1/CYxTnSZE/LNg==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/actor-rdf-parse-html": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.15.0.tgz",
+      "integrity": "sha512-eC43jtLqY3wfA6aRim83l+3NfoMQCZv/lPP2MvqxY04/Rk77DdqKtKS2GfYrIBc8aqDOoreVgiBQG5TzPzm5Ew==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "htmlparser2": "^4.0.0"
+      }
+    },
+    "@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.15.0.tgz",
+      "integrity": "sha512-1rA7YCjY1v7/1oRKzthVw633HZmHux96SQW5j+FIJTvX4GoBvf1seS082HY7WQGRpZVgLxOUxtAOQcp7zT4dHA==",
+      "dev": true,
+      "requires": {
+        "rdfa-streaming-parser": "^1.1.1"
+      }
+    },
+    "@comunica/actor-rdf-parse-html-script": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.16.1.tgz",
+      "integrity": "sha512-IYagk0RzIQEzj/78KvoICDgOiPnwvj44S/PH2ha++o9Se0FgTxRjHrWTluETiczOcvrV54TeVh0YDYJck+xz/w==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-parse-jsonld": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.16.0.tgz",
+      "integrity": "sha512-LtAIv75bhHe2teN0vjWZ6EkjwnK6Yw56Q1ZuxgrWZLGrbdRF6YZuXglW+IqWeZ45tIUqhweS83k17/9fR3UK5w==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "jsonld-streaming-parser": "^2.0.2",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "@comunica/actor-rdf-parse-n3": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.15.0.tgz",
+      "integrity": "sha512-YWk7XSDN8GDOFL+u5PtadZmIUzAh5ZUYB/LwXLENeymIgWEaSvJo5H4QqdGmnJFArlgXX2Thk8jTvbtubiNTvw==",
+      "dev": true,
+      "requires": {
+        "@types/n3": "^1.4.2",
+        "n3": "^1.0.0"
+      }
+    },
+    "@comunica/actor-rdf-parse-rdfxml": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.15.0.tgz",
+      "integrity": "sha512-Rec0dnaTW95Mx91cfQPBkDkgEhoFd9J36FtiJAotLFPOiXp4YsTEZGQNSODTbhchfaTS6HDTFnETQ6GbmutaCQ==",
+      "dev": true,
+      "requires": {
+        "rdfxml-streaming-parser": "^1.1.0"
+      }
+    },
+    "@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.15.0.tgz",
+      "integrity": "sha512-34CI/f/JQTEfrnxyqB7Y+EhkhW0tTMsHoC8yu+Y6AtSVdj2FYkSR+GmAk9F65JVnm/RC9uh1T7yT5yJMVvmgiQ==",
+      "dev": true,
+      "requires": {
+        "rdfa-streaming-parser": "^1.1.1"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-links-next": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.15.0.tgz",
+      "integrity": "sha512-TgQurH1G50rdgnQ9WCWchYrUDMk+379oVuha5JISwW5Dc33/wVjR+hoIkrAfKx/kIi7846mcEHO4qNQ5V818hw==",
+      "dev": true
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-none": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.15.0.tgz",
+      "integrity": "sha512-dgCFXKbmY9UKSaczpmdVFeSNNcotgWJavC979HQO40zjq6tg3kRDT82M0ucjuDB7fIglzA8xQYTvbjIWYNrm4g==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "rdf-store-stream": "^1.0.1"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-qpf": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.16.0.tgz",
+      "integrity": "sha512-ikOdP68hwoG9jFqe7ezpOfvWirXtFmKjCvbWf6bl4HgojvP8Wa94V7glxV75p/8Tsj5j5FwvFJfbbhlBJDNXiQ==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.0",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "rdf-string": "^1.4.2",
+        "rdf-terms": "^1.5.1"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-sparql": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.16.0.tgz",
+      "integrity": "sha512-G6OCciGr/mGg6TQ4+iEnWgSqYyrKmhXQ8UzkLPS6FJXyxWJoEoiHpebYMN9Zw6XycJKnZxlqVUrmIuz3Cxde5g==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.16.0",
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "rdf-terms": "^1.4.0",
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-federated": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.16.0.tgz",
+      "integrity": "sha512-bHQLxjCtDHiUxIop8IWfReZhBPWpusPfc39A65VyQsZ7lBF/ZF21fTDaGJ8XlmiAYNBanDwjVIKe5ng3MGzwww==",
+      "dev": true,
+      "requires": {
+        "@comunica/data-factory": "^1.14.0",
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "rdf-terms": "^1.5.1"
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.16.0.tgz",
+      "integrity": "sha512-eNcn6N5Db5NyBPf4/on+baLr6pqeO86OcbfrjHkdU98MnR5CTXMF68/MCkwRLfcYooRG+o6z6EV/T/wonVeT8g==",
+      "dev": true,
+      "requires": {
+        "@comunica/utils-datasource": "^1.16.0",
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/lru-cache": "^5.1.0",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "lru-cache": "^6.0.0",
+        "rdf-string": "^1.4.2",
+        "rdf-terms": "^1.5.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.16.0.tgz",
+      "integrity": "sha512-+APHJ2NNegd+dtbMIRnNKksBWk4lqEE70snWBKLavxcae0oq6rq3IvZypuARQETFfxICK9KtAtwg6Z7G19QjKw==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.16.0.tgz",
+      "integrity": "sha512-TfeEDKaYCR3NZvOmhaUY49+Z+5vPKRnx3xTA5L1GsvsU4Bc2kdFKI7ax7FR1p3CrM7AHDlxvu8/AzHIAWFbtxg==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "rdf-terms": "^1.4.0",
+        "sparqlalgebrajs": "^2.3.2",
+        "sparqljson-parse": "^1.5.0"
+      }
+    },
+    "@comunica/actor-rdf-serialize-jsonld": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.15.0.tgz",
+      "integrity": "sha512-+QeLhBWY9Ce0sNW6yDm7GoEdFNlMsQ01k71yBhaBRPhe/gYEbJc0chZAUoByCY0dJRqtfZK1Wc5gjfTrG/ctdQ==",
+      "dev": true,
+      "requires": {
+        "jsonld-streaming-serializer": "^1.1.0"
+      }
+    },
+    "@comunica/actor-rdf-serialize-n3": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.15.0.tgz",
+      "integrity": "sha512-/9wY7o875w103A9a/SNpk65rFcp+bT3mSOnjV1bUnMVhvy73AsRG88uiwGUbS6GDFBPzA2j/l8OD+I4U3j6I7Q==",
+      "dev": true,
+      "requires": {
+        "@types/n3": "^1.4.2",
+        "@types/rdf-js": "^3.0.0",
+        "n3": "^1.0.0",
+        "rdf-string": "^1.4.2"
+      }
+    },
+    "@comunica/actor-sparql-parse-algebra": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.16.0.tgz",
+      "integrity": "sha512-hby1X7JYxgS1T84bLYna2Cs5XCA4cCaUJMAJ8emd/IyHoW0VT4N0moCofnswjykeJ9HgCOWMbs6FqfahZS1Tag==",
+      "dev": true,
+      "requires": {
+        "@types/sparqljs": "^3.0.0",
+        "rdf-string": "^1.4.2",
+        "sparqlalgebrajs": "^2.3.2",
+        "sparqljs": "^3.1.1"
+      }
+    },
+    "@comunica/actor-sparql-parse-graphql": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.15.0.tgz",
+      "integrity": "sha512-QggTh7b/LgzZRqKR+p46hXoJiH5ge/JTbWQM92QCRa2TsNm2hGpuvCwUS0VoPiUN+O/Vbtw6IH+09qJAnEt0+w==",
+      "dev": true,
+      "requires": {
+        "graphql-to-sparql": "^2.1.0"
+      }
+    },
+    "@comunica/actor-sparql-serialize-json": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.16.0.tgz",
+      "integrity": "sha512-9T6WlZtCOvYm37j7tgGvRCYO716naaqG4V2LbIYVcxoCxqUlfPcpE07eXt8GfWEG9R6QQuvk8UvEPqZrNiPmNQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "rdf-string": "^1.4.2"
+      }
+    },
+    "@comunica/actor-sparql-serialize-rdf": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.16.0.tgz",
+      "integrity": "sha512-KBwIuwzZp5qoSFPy+8n81x2uuV8P6pzwG3r2skdir+CfIygGb0Yxf0EzCKfVDBCYn/h4lFJPwMbqXbfflwN7Ww==",
+      "dev": true
+    },
+    "@comunica/actor-sparql-serialize-simple": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.16.0.tgz",
+      "integrity": "sha512-Cu4MpzGlXQn/tI68fKuttny6cPmvyFBllypkZybPOtGwMY/TyA5FSd/GQLCagfP/gSm6XYnmK04D8gzY1Bwrlw==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/actor-sparql-serialize-sparql-csv": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.16.0.tgz",
+      "integrity": "sha512-unsuwwpuXdf+mqnrlFws/XpywRCPMjXccXZo2ORNlV4/iuWB3pIToAW0dnhTNxXafpWKiN/lcX05xQitH6jm3Q==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/actor-sparql-serialize-sparql-json": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.16.0.tgz",
+      "integrity": "sha512-JVAPseFNzUT82mH9udR2QJXw0uWo6TcpHVYXk0JbvXOXwH4NBuAkXiYFBMv1ghbtpyN31Xol7Pa90mwGb8rrMw==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/actor-sparql-serialize-sparql-tsv": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.16.0.tgz",
+      "integrity": "sha512-GX6ELMgGa3ztPZC2jKQ6/xyYf+fg4p/6p/ww/GzrSplEpmRlKFQIgUCu735ZKM3w5lZdxf8IDzOeVqDARI8jhw==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "rdf-string-ttl": "^1.0.1"
+      }
+    },
+    "@comunica/actor-sparql-serialize-sparql-xml": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.16.0.tgz",
+      "integrity": "sha512-udTwQMSGY25S9YePdMKrWgndHrxhcFpEZ2u8msTxbZkkJZhW8qKxh4rMUE5ESGsrFPwtlYQTX+gPu2LZ+zXAnA==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "@types/xml": "^1.0.2",
+        "xml": "^1.0.1"
+      }
+    },
+    "@comunica/actor-sparql-serialize-stats": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.16.0.tgz",
+      "integrity": "sha512-tGeOR5tgyP7yG7fSiPuI2Md+/ZFRJk8A6eSXGAGvZaNTGIhDmaF21jLfon/OUrJTO3jlsR1a1mZ2Hl5jshp2kA==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/actor-sparql-serialize-table": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.16.0.tgz",
+      "integrity": "sha512-Sj5AJqP5fPEL8Nr2sG6K64crd7FOChPzFojSE6L750SXutQSNDuJ/Zm8N1xfZxGsxTeYNUhzr+WxzSKoWuwzQA==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "rdf-terms": "^1.4.0"
+      }
+    },
+    "@comunica/actor-sparql-serialize-tree": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.16.0.tgz",
+      "integrity": "sha512-9BMQ8nL4Cso2NOsiKrcGQp/Ccmer8jhfJowOQhRioLI54w2+lVGXBfR8t/Mj9T4bWabtgY8AES25ZjGS2hh2gg==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "sparqljson-to-tree": "^2.0.0"
+      }
+    },
+    "@comunica/bus-context-preprocess": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.15.0.tgz",
+      "integrity": "sha512-qB+DQX2YiXjc/vJ84fE9nW6XXgMDbYIwgtjn5wmfvQWjr+9p0yVjk32IMU9kRa7ETp9OytY/pHebvVHDhuHBYw==",
+      "dev": true
+    },
+    "@comunica/bus-http": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.16.0.tgz",
+      "integrity": "sha512-3fWJA3Yh7Wj4clabg141FgAH+m8/InZ+BVPr7BqhO+7Jg0tXbvGDfai8N0SXWL7rCMkWjlPYkBHkzpQ8Dk0HAg==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "web-streams-node": "^0.4.0"
+      }
+    },
+    "@comunica/bus-http-invalidate": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.15.0.tgz",
+      "integrity": "sha512-RGURwbcUtD81ZYMMqs3EXB8ML35HENnGnrnrl0iO07R8HdJ/V5sczM8cxo5/+MXDpAqA9ao99AHJARwyHgoFmQ==",
+      "dev": true
+    },
+    "@comunica/bus-init": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.15.0.tgz",
+      "integrity": "sha512-HwVTEznx2H7GvcfQAREz52QF8xXT1AqxkJDnI9vTeGvLpWrM+LVOAJZxBcYFFK3X3bEhTsPfDVzikziMGqZuZw==",
+      "dev": true
+    },
+    "@comunica/bus-optimize-query-operation": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.16.0.tgz",
+      "integrity": "sha512-7mvHenP7semqGlWge4EIvueK1/s4TjMpyL/RKF0Twa8Fwp0r66dFjprkAitV7K95U4FJvD0KSJPWTnQsJBdxrg==",
+      "dev": true,
+      "requires": {
+        "sparqlalgebrajs": "^2.3.2"
+      }
+    },
+    "@comunica/bus-query-operation": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.16.0.tgz",
+      "integrity": "sha512-xusr0PelD5ej1B9+ff7AFDXRMidDR167Lzazaits7wNd400sG2RpIJjnEvNqU6g6d0R5WnUWCpCuv4hFQZ15sQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "immutable": "^3.8.2"
+      }
+    },
+    "@comunica/bus-rdf-dereference": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.15.0.tgz",
+      "integrity": "sha512-4vXq8e51zK1gkw5lxL2HkqYx/Wig215w8Bi3jguUTM/10EQW7KgebhRxeFU/EQOamFTMeS5anOu5BVfNps8rJQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/bus-rdf-dereference-paged": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.15.0.tgz",
+      "integrity": "sha512-xejwEanK8yaI/ST1SDE2Tjs9f/PsS5SvtYIVEZuWew9Ey4UlxcW/Tsz4m5YA40DeYbXaXg7m40ZeWJxwiislrw==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/bus-rdf-join": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.16.0.tgz",
+      "integrity": "sha512-v2RilDXPIc1sOtGnhskNqvbeyp4jOBTTUnHUEHCIdopZVUhEIj+zpZdHFoPOIbtHK6eQlQ0Ckx3E3mX84fZVyA==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/bus-rdf-metadata": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.15.0.tgz",
+      "integrity": "sha512-XhyMkScTBA0KUPTHtmO+kxAUyHhvuigiC6NzAoBZ9wm4y+r3aZ++mpBpAv/Fyma5GiT19EAW2pa8ew7CV9GR3A==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/bus-rdf-metadata-extract": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.15.0.tgz",
+      "integrity": "sha512-uxLy3hvpWuLoopoG5clYb3imhQXHGHMKHXe97jfvXA0hjoWleNtD0KRfhs+45YCBXqfNC9PVypTb9eM6SVILNQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "graphql-ld": "^1.1.0",
+        "rdf-store-stream": "^1.0.1"
+      }
+    },
+    "@comunica/bus-rdf-parse": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.15.0.tgz",
+      "integrity": "sha512-6cGGUBgorkJ6hr5U235qSrlK1m7rPpIM8W6o9kbRAw149AKap1XFF3OXpAYqat2eB4Cbs1J2PP9wg1/s/uOsww==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^1.15.0",
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/bus-rdf-parse-html": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.15.0.tgz",
+      "integrity": "sha512-7F/kDrNf9X//IrO/CK4LpwM5f+mFHLa/wsPc2RubyhiFN3P3KWU6NWxjDJRT9yP85EmW4KknXWwF8AOTvbKF1A==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/bus-rdf-resolve-hypermedia": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.15.0.tgz",
+      "integrity": "sha512-mnSsNMa2FS6x0b0K453J4c2+1UQoe2WX/p3UXfF7YocWFc7eL7JUsZO8+XZ1Pq8WaPpz+sUeaz+JtIYgVtqSGg==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "asyncreiterable": "^2.0.0"
+      }
+    },
+    "@comunica/bus-rdf-resolve-hypermedia-links": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.15.0.tgz",
+      "integrity": "sha512-AJD48ftgMdPj5x0hMTRkzNHeywsMqWnXOK7c6L2m3TlUyMtw5PWNYKd2CD1qyXE7xmSi2cKLKA5TKDkQqV7GCg==",
+      "dev": true
+    },
+    "@comunica/bus-rdf-resolve-quad-pattern": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.16.0.tgz",
+      "integrity": "sha512-CHZQcBFVMeUiB2DyGWzDRzvXO+s7uNS6SwnrvXVujCpdYFKfB15uG9mcpc8tZGwHDr18xq6iuLZcEKMl5wqGjA==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.1",
+        "asyncreiterable": "^2.0.0"
+      }
+    },
+    "@comunica/bus-rdf-serialize": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.15.0.tgz",
+      "integrity": "sha512-c1uJF1LkJ96zscMCe+CB2fLbXhlJ0o8PPVRMm3Jk7/rc8WY5bUxSxf1SFbA/jkOZtcZy59wFHDvPf/NM74ADBg==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^1.15.0",
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/bus-sparql-parse": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.15.0.tgz",
+      "integrity": "sha512-4aFz5qnnnPxezK/vtvltqqUlN0NhYNFEQwXYZf6Yi2dSS/Hs4cU4kYcldXxIXeBfRQkaoUtTCr0lCUg5uOyqIQ==",
+      "dev": true
+    },
+    "@comunica/bus-sparql-serialize": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.16.0.tgz",
+      "integrity": "sha512-LLPheBBYBuSAweou+4kQf0Gop/lNORXOuaDfsHemLG6VqNmWzYyl79rnjd7yTLcZn/QVMUUYDD21CPY8OU5lJQ==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^1.15.0"
+      }
+    },
+    "@comunica/core": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.15.0.tgz",
+      "integrity": "sha512-Mg/fpufyK4hVKX2vgP8oapu4ZpyugNRxyI/1AX7zlhSkYpE+ldK5YQaGG/sb+fq+s2sAtE1Ocd+thCgF4wv+8w==",
+      "dev": true,
+      "requires": {
+        "immutable": "^3.8.2"
+      }
+    },
+    "@comunica/data-factory": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-1.14.0.tgz",
+      "integrity": "sha512-zpTpglsFIHuklarPCFTG2nRRG+RD1biT9nscggltShKJRK2EAtpnMeABGS/QU6es5CC96ZdA94KlVmFxt51A+g==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "@comunica/logger-pretty": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.15.0.tgz",
+      "integrity": "sha512-Ta0u/YHHgSvX9Au8JqzhgqmNiPLwFW2L1ZLnUR3V0J+uQDL2PEayWnw+xrDyVKgYJaffevJYHowjn4c4D5DxFA==",
+      "dev": true
+    },
+    "@comunica/logger-void": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.15.0.tgz",
+      "integrity": "sha512-nU0bJ56hOAURnz4uDNbeldAJ88OduRQMtHEeKTSkR+ATArP/ShXFWLgKcxRnU9ELSsA7k9HlvAFpvag5+eNs8g==",
+      "dev": true
+    },
+    "@comunica/mediator-all": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.15.0.tgz",
+      "integrity": "sha512-uALhqOxGIT/gBXWkIVE+PTITf5EIDNL2UD9GRffdgc1Qg74prWcMZ4+gYczBOMUhqZHE605QsXXO8NkT4xP14A==",
+      "dev": true
+    },
+    "@comunica/mediator-combine-pipeline": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.15.0.tgz",
+      "integrity": "sha512-XYf+rOSF1Tj5JX8geHUt5O8BJmLqyRXXYZQe2nlwGoe66hshMKpzAu38m5uDpARrJ4dPxU0PrH34x1Wug77lpg==",
+      "dev": true
+    },
+    "@comunica/mediator-combine-union": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.15.0.tgz",
+      "integrity": "sha512-TPzfXuKRVBEpjb+/S8v2C8uvgi8BTjtg1htL/qY/xI2fYqRcLZGl+D5MZEESmwpmm19cBfg87CbF+ROn6L3+IQ==",
+      "dev": true
+    },
+    "@comunica/mediator-number": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.15.0.tgz",
+      "integrity": "sha512-d1jwHVN6rELFzEPb+CDqEjItAJ4/AqiP1Vp+Z/PBucLjM9EEonQMjQzqrkRV/Oy6cBXfSQDhXuSvftfl/zUCjg==",
+      "dev": true
+    },
+    "@comunica/mediator-race": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.15.0.tgz",
+      "integrity": "sha512-MVESJnkgSoPaCkNNN8RDm0B06d0JNL4QOvRZFuFETY4/D+OwIpcEf0EGButQsDUlelAk5n/sFssLMqo2tw65SA==",
+      "dev": true
+    },
+    "@comunica/runner": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.16.0.tgz",
+      "integrity": "sha512-ZQuTt10UpcUbiXu94MSFCgaYkraCtgXewEbXus5Jf0OUbSqa/fkxwWs4wTxak/9CjtFLMb4GO3jfoYoeWbqtfA==",
+      "dev": true,
+      "requires": {
+        "componentsjs": "^3.4.1"
+      }
+    },
+    "@comunica/runner-cli": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.16.0.tgz",
+      "integrity": "sha512-9XfRqACWeppe/po/UMIN4MH+gU/8YszRqyPG02vd9k0AnPXYMK5AXPj4ge3D0HQE+ENb2y9C5xe516w0yl8eBw==",
+      "dev": true,
+      "requires": {
+        "@comunica/runner": "^1.16.0"
+      }
+    },
+    "@comunica/utils-datasource": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.16.0.tgz",
+      "integrity": "sha512-MWng1lz62YT5VLvwFvBNc119U6aNvX7oL8j7YdgRyLulB14gYEp5njuqRjbz1WFa1TtDUJxYGMPyskSMdzGilw==",
+      "dev": true,
+      "requires": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.16.0",
+        "arrayify-stream": "^1.0.0",
+        "asynciterator": "^3.0.1",
+        "asyncreiterable": "^2.0.0"
+      }
+    },
     "@emmetio/extract-abbreviation": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@emmetio/extract-abbreviation/-/extract-abbreviation-0.1.6.tgz",
@@ -2819,6 +4137,12 @@
       "requires": {
         "@hapi/hoek": "^8.3.0"
       }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
     },
     "@koa/cors": {
       "version": "3.1.0",
@@ -2868,24 +4192,25 @@
       "dev": true
     },
     "@open-wc/building-rollup": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@open-wc/building-rollup/-/building-rollup-1.4.2.tgz",
-      "integrity": "sha512-9ZDCrC6RqFQBBLoEyqQI8NBD48LDE5KXL4qAnqjrEXOhsWMmHcgEgIRTN4Jl6wYyvbXOJ1bT8PckR5576gIMHw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/building-rollup/-/building-rollup-1.8.0.tgz",
+      "integrity": "sha512-DuaBtbMlb8llBp3K0hVACbq7My/jc9PeGsfIxx/qwE2uzkTcYkedHi62rhKFWG2gLvcSPdFDxzZt/klhRWlxIQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.9.0",
-        "@babel/helpers": "^7.9.2",
-        "@babel/plugin-proposal-dynamic-import": "^7.8.3",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-proposal-optional-chaining": "^7.9.0",
+        "@babel/core": "^7.11.1",
+        "@babel/helpers": "^7.10.4",
+        "@babel/plugin-proposal-dynamic-import": "^7.10.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.11.0",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.8.3",
-        "@babel/plugin-transform-modules-systemjs": "^7.9.0",
-        "@babel/plugin-transform-runtime": "^7.9.0",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-transform-modules-systemjs": "^7.10.5",
+        "@babel/plugin-transform-runtime": "^7.11.0",
         "@babel/preset-env": "^7.9.0",
-        "@open-wc/building-utils": "^2.18.0",
-        "@open-wc/rollup-plugin-html": "^1.1.0",
-        "@open-wc/rollup-plugin-polyfills-loader": "^1.0.7",
+        "@open-wc/building-utils": "^2.18.1",
+        "@open-wc/rollup-plugin-html": "^1.2.3",
+        "@open-wc/rollup-plugin-polyfills-loader": "^1.1.4",
+        "@rollup/plugin-babel": "^5.1.0",
         "@rollup/plugin-node-resolve": "^7.1.1",
         "babel-plugin-bundled-import-meta": "^0.3.2",
         "babel-plugin-template-html-minifier": "^4.0.0",
@@ -2894,19 +4219,18 @@
         "magic-string": "^0.25.7",
         "parse5": "^5.1.1",
         "regenerator-runtime": "^0.13.3",
-        "rollup-plugin-babel": "^5.0.0-alpha.1",
         "rollup-plugin-terser": "^5.2.0",
         "rollup-plugin-workbox": "^5.0.1",
         "terser": "^4.6.7"
       }
     },
     "@open-wc/building-utils": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.18.0.tgz",
-      "integrity": "sha512-U1n8sLQlLt3IuqhU7tDsGQAGUfVMiB64xJsAmJEtekposrjqkjtRLU/WipvROl1A2GTsrMojMjNbFqzJghpd6g==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.18.1.tgz",
+      "integrity": "sha512-FBSlR94BwrVlHcaWSESzlYOVLqrUKnC8L88yHajCm/cONaEWYhP/O7SXVHgLnXkjYbCgCGMKbq6fuSnwf5jElQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.9.0",
+        "@babel/core": "^7.11.1",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@webcomponents/shadycss": "^1.9.4",
         "@webcomponents/webcomponentsjs": "^2.4.0",
@@ -2953,35 +4277,35 @@
       }
     },
     "@open-wc/dedupe-mixin": {
-      "version": "1.2.18",
-      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.2.18.tgz",
-      "integrity": "sha512-1HpblP5edeENi0SKms7B+PKYdxHMBIQpaf0nAgTVsZeYgM9OJ3r9nrK/0MOUBZODAOZ1quvO3wlpuljq2hZPWA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.3.0.tgz",
+      "integrity": "sha512-UfdK1MPnR6T7f3svzzYBfu3qBkkZ/KsPhcpc3JYhsUY4hbpwNF9wEQtD4Z+/mRqMTJrKg++YSxIxE0FBhY3RIw=="
     },
     "@open-wc/karma-esm": {
-      "version": "2.16.17",
-      "resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-2.16.17.tgz",
-      "integrity": "sha512-lVmlnbmYE5bMnVGs8J+Ve1sK3fRGXx8q5JRVtEyefoUh3hievdgPo5RbST+PHguDMl47BsH43urbIx++DEcp5Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-3.0.5.tgz",
+      "integrity": "sha512-T4bSjEPAizT4TLcULLg4/DT/gLvddeUTX3zgdON8Cns0mSy/HdWy/rWfdEbG65u6343PmZZ102h+tQhC7l+YGA==",
       "dev": true,
       "requires": {
-        "@open-wc/building-utils": "^2.18.0",
+        "@open-wc/building-utils": "^2.18.1",
         "babel-plugin-istanbul": "^5.1.4",
         "chokidar": "^3.0.0",
         "deepmerge": "^4.2.2",
-        "es-dev-server": "^1.56.1",
+        "es-dev-server": "^1.57.4",
         "minimatch": "^3.0.4",
         "node-fetch": "^2.6.0",
-        "polyfills-loader": "^1.6.1",
+        "polyfills-loader": "^1.7.1",
         "portfinder": "^1.0.21",
         "request": "^2.88.0"
       }
     },
     "@open-wc/rollup-plugin-html": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-html/-/rollup-plugin-html-1.1.0.tgz",
-      "integrity": "sha512-0VukjFUtC3Ro+kZcQMQqlE9B+FjOTXKJP1ek2jjT1HqeoG5NCHrgGCFe/fLc4G1TDDM5fIuKZ/xcus4TtICWTA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-html/-/rollup-plugin-html-1.2.3.tgz",
+      "integrity": "sha512-0Xd90QrOHTN8OIlAK+RWdp2SiscRpwWHpootLHVoyz3nUZPy6sjE5W6gGlZHe2Zc59iBs7ai+CecH2RlaqrX2A==",
       "dev": true,
       "requires": {
-        "@open-wc/building-utils": "^2.18.0",
+        "@open-wc/building-utils": "^2.18.1",
         "@types/html-minifier": "^3.5.3",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
@@ -3004,43 +4328,43 @@
       }
     },
     "@open-wc/rollup-plugin-polyfills-loader": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-polyfills-loader/-/rollup-plugin-polyfills-loader-1.0.7.tgz",
-      "integrity": "sha512-ax7jcXWUZaBDO7g3deRvtGNKPHoB9MzHqNAbSqkIY9R1D8cSluzN4LMHdWs0tWKfZzIRJljNvM/1glQqthlJ9A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-polyfills-loader/-/rollup-plugin-polyfills-loader-1.1.4.tgz",
+      "integrity": "sha512-jNUdsmVgSwiRriEzbaeiR8CB3YDyw0Vljt/35A4iluMyNst8S1S0v7aDi0aa6h0MzmC7JRAP6EEpJ2QfjzmY5A==",
       "dev": true,
       "requires": {
-        "@open-wc/rollup-plugin-html": "^1.1.0",
-        "polyfills-loader": "^1.6.1"
+        "@open-wc/rollup-plugin-html": "^1.2.3",
+        "polyfills-loader": "^1.7.1"
       }
     },
     "@open-wc/scoped-elements": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-1.1.2.tgz",
-      "integrity": "sha512-2aZ8Ibfxhn1+ipBTvL8l84JTzptmGOd5NiLqlojn4QJQnJ/mEQXf9+g/Jj991ga+3nt1R+vRlO4JSrgqkCiyIQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-1.2.2.tgz",
+      "integrity": "sha512-C3JU79gNBmcxqKqZ8aTargPmBBwQvyws6lhfZ+9I0NH8SKk0k6ExjzyUwsDa2i/kbhBuUE5NebaDZJM5Jw4/6w==",
       "dev": true,
       "requires": {
-        "@open-wc/dedupe-mixin": "^1.2.18",
+        "@open-wc/dedupe-mixin": "^1.3.0",
         "lit-html": "^1.0.0"
       }
     },
     "@open-wc/semantic-dom-diff": {
-      "version": "0.17.9",
-      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.17.9.tgz",
-      "integrity": "sha512-wO4xM3FhLmGGZM3wDexUPFb55tqVX45LJQ9l3uNKj1Roi0/aV1KjIohdE2J0zUJivfCxAWo1Dy45hNkCHO4CVA==",
+      "version": "0.17.10",
+      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.17.10.tgz",
+      "integrity": "sha512-7RAJqHsaFGA8LoBlgaScTxSu5FXga89Af1RXv3n/Rmv/x/W5mmyIKMfUR3F/RJofm2/FwnLWtaHgwS9qB1eNfg==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.2.11"
       }
     },
     "@open-wc/testing": {
-      "version": "2.5.19",
-      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-2.5.19.tgz",
-      "integrity": "sha512-0+dQgZbS76p55XS5fwA3BlKje+i6BIR68Ntl88lFdMqjQv02lPHHlkakZeLd6xv1hRdQlj0XIj1YIIaE18CMAA==",
+      "version": "2.5.25",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-2.5.25.tgz",
+      "integrity": "sha512-j+i3YDLDmarb2ZRy/NdRY/y2PyEB48rrMUJrOg1/yxmgAp9xACVeQROBFL1h7I3HgyaG84KPXhJ8T6GRXUR7Qg==",
       "dev": true,
       "requires": {
         "@open-wc/chai-dom-equals": "^0.12.36",
-        "@open-wc/semantic-dom-diff": "^0.17.9",
-        "@open-wc/testing-helpers": "^1.8.4",
+        "@open-wc/semantic-dom-diff": "^0.17.10",
+        "@open-wc/testing-helpers": "^1.8.9",
         "@types/chai": "^4.2.11",
         "@types/chai-dom": "^0.0.9",
         "@types/mocha": "^5.0.0",
@@ -3053,23 +4377,23 @@
       }
     },
     "@open-wc/testing-helpers": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-1.8.4.tgz",
-      "integrity": "sha512-YkObNL45tX3z4MYoJnTNRRqqH8qcTmF1pqzQBRnO7XOGelktOamEODcr+YYOpftlbPFvLyegYy2wMy6M+Szdyg==",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-1.8.9.tgz",
+      "integrity": "sha512-M7pPOE1tjSW06Kavft4vlQcRf0RGbPeaBqGn57YHYw05XxbY3ZDoJGA8hwaA0jyuLbv8XTwOJwtwHJf6fuRE4w==",
       "dev": true,
       "requires": {
-        "@open-wc/scoped-elements": "^1.1.2",
+        "@open-wc/scoped-elements": "^1.2.2",
         "lit-element": "^2.2.1",
         "lit-html": "^1.0.0"
       }
     },
     "@open-wc/testing-karma": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-3.4.7.tgz",
-      "integrity": "sha512-Ynb+/tpNNZTA5oCetGATP00/XO/lC/+eg0hwypmxJP7gQnzOpzgY2/bTvxq43bDHQ1xC2sutZKUevVhBkniLLg==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-3.4.8.tgz",
+      "integrity": "sha512-k74u4SAjomZU0GBhFRXVPYOzNLr++ytqvBQwTwhS32TdwFVC4BY/z2E3cjyYbARsiLFHQOV/uo/fYLHzowoK1g==",
       "dev": true,
       "requires": {
-        "@open-wc/karma-esm": "^2.16.17",
+        "@open-wc/karma-esm": "^2.16.18",
         "@types/karma": "^5.0.0",
         "@types/karma-coverage-istanbul-reporter": "^2.1.0",
         "@types/karma-mocha": "^1.3.0",
@@ -3084,6 +4408,224 @@
         "karma-snapshot": "^0.6.0",
         "karma-source-map-support": "^1.3.0",
         "mocha": "^6.2.2"
+      },
+      "dependencies": {
+        "@open-wc/karma-esm": {
+          "version": "2.16.18",
+          "resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-2.16.18.tgz",
+          "integrity": "sha512-K+HeXqRdvOupnlRr7rHgBFSqgyr5E0KNS89BTnHN0qKcDpa+M+m1sZHInPrB+iFqLQ7hhWNeGmtesDFfnIBhaQ==",
+          "dev": true,
+          "requires": {
+            "@open-wc/building-utils": "^2.18.0",
+            "babel-plugin-istanbul": "^5.1.4",
+            "chokidar": "^3.0.0",
+            "deepmerge": "^4.2.2",
+            "es-dev-server": "^1.57.0",
+            "minimatch": "^3.0.4",
+            "node-fetch": "^2.6.0",
+            "polyfills-loader": "^1.6.1",
+            "portfinder": "^1.0.21",
+            "request": "^2.88.0"
+          }
+        },
+        "base64id": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+          "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "engine.io": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
+          "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "base64id": "1.0.0",
+            "cookie": "0.3.1",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.0",
+            "ws": "~3.3.1"
+          }
+        },
+        "engine.io-client": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+          "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "component-inherit": "0.0.3",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.1",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "ws": "~3.3.1",
+            "xmlhttprequest-ssl": "~1.5.4",
+            "yeast": "0.1.2"
+          }
+        },
+        "engine.io-parser": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+          "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+          "dev": true,
+          "requires": {
+            "after": "0.8.2",
+            "arraybuffer.slice": "~0.0.7",
+            "base64-arraybuffer": "0.1.5",
+            "blob": "0.0.5",
+            "has-binary2": "~1.0.2"
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        },
+        "isbinaryfile": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+          "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+          "dev": true,
+          "requires": {
+            "buffer-alloc": "^1.2.0"
+          }
+        },
+        "karma": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/karma/-/karma-4.4.1.tgz",
+          "integrity": "sha512-L5SIaXEYqzrh6b1wqYC42tNsFMx2PWuxky84pK9coK09MvmL7mxii3G3bZBh/0rvD27lqDd0le9jyhzvwif73A==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.3.0",
+            "body-parser": "^1.16.1",
+            "braces": "^3.0.2",
+            "chokidar": "^3.0.0",
+            "colors": "^1.1.0",
+            "connect": "^3.6.0",
+            "di": "^0.0.1",
+            "dom-serialize": "^2.2.0",
+            "flatted": "^2.0.0",
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "http-proxy": "^1.13.0",
+            "isbinaryfile": "^3.0.0",
+            "lodash": "^4.17.14",
+            "log4js": "^4.0.0",
+            "mime": "^2.3.1",
+            "minimatch": "^3.0.2",
+            "optimist": "^0.6.1",
+            "qjobs": "^1.1.4",
+            "range-parser": "^1.2.0",
+            "rimraf": "^2.6.0",
+            "safe-buffer": "^5.0.1",
+            "socket.io": "2.1.1",
+            "source-map": "^0.6.1",
+            "tmp": "0.0.33",
+            "useragent": "2.3.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "socket.io": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+          "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+          "dev": true,
+          "requires": {
+            "debug": "~3.1.0",
+            "engine.io": "~3.2.0",
+            "has-binary2": "~1.0.2",
+            "socket.io-adapter": "~1.1.0",
+            "socket.io-client": "2.1.1",
+            "socket.io-parser": "~3.2.0"
+          }
+        },
+        "socket.io-client": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+          "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+          "dev": true,
+          "requires": {
+            "backo2": "1.0.2",
+            "base64-arraybuffer": "0.1.5",
+            "component-bind": "1.0.0",
+            "component-emitter": "1.2.1",
+            "debug": "~3.1.0",
+            "engine.io-client": "~3.2.0",
+            "has-binary2": "~1.0.2",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "object-component": "0.0.3",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "socket.io-parser": "~3.2.0",
+            "to-array": "0.1.4"
+          }
+        },
+        "socket.io-parser": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+          "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "debug": "~3.1.0",
+            "isarray": "2.0.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
+        }
       }
     },
     "@polymer/app-layout": {
@@ -3438,6 +4980,36 @@
         "prismjs": "^1.11.0"
       }
     },
+    "@rdfjs/data-model": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.2.tgz",
+      "integrity": "sha512-pk/G/JLYGaXesoBLvEmoC/ic0H3B79fTyS0Ujjh5YQB2DZW+mn05ZowFFv88rjB9jf7c1XE5XSmf8jzn6U0HHA==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^2.0.1"
+      },
+      "dependencies": {
+        "@types/rdf-js": {
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.12.tgz",
+          "integrity": "sha512-NBzHFHp2vHOJkPlSqzsOrkEsD9grKn+PdFjZieIw59pc0FlRG6WEQAjQZvHzFxJlYzC6ZDCFyTA1wBvUnnzUQw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
+    },
+    "@rollup/plugin-babel": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.0.tgz",
+      "integrity": "sha512-CPABsajaKjINgBQ3it+yMnfVO3ibsrMBxRzbUOUw2cL1hsZJ7aogU8mgglQm3S2hHJgjnAmxPz0Rq7DVdmHsTw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@rollup/pluginutils": "^3.1.0"
+      }
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -3507,9 +5079,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
-      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
@@ -3666,9 +5238,9 @@
       "dev": true
     },
     "@types/chai": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-      "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+      "integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
       "dev": true
     },
     "@types/chai-dom": {
@@ -3755,6 +5327,15 @@
         "@types/node": "*"
       }
     },
+    "@types/create-hash": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
+      "integrity": "sha512-Fg8/kfMJObbETFU/Tn+Y0jieYewryLrbKwLCEIwPyklZZVY2qB+64KFjhplGSw+cseZosfFXctXO+PyIYD8iZQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/cssbeautify": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
@@ -3807,9 +5388,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
-      "integrity": "sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==",
+      "version": "4.17.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz",
+      "integrity": "sha512-DG0BYg6yO+ePW+XoDENYz8zhNGC3jDDEpComMYn7WJc4mY1Us8Rw9ax2YhJXxpyk2SF47PQAoQ0YyVT1a0bEkA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -3860,10 +5441,28 @@
       "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
       "dev": true
     },
+    "@types/http-errors": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.0.tgz",
+      "integrity": "sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA==",
+      "dev": true
+    },
+    "@types/http-link-header": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.1.tgz",
+      "integrity": "sha512-5h+Pqs4EHoMkY/fLva7XsYmh9IVQghQ6uWWil1FGCNI0WqjhI4g20doYsbT4kJ/G3GkAlQca4AIc9OexdUnzkg==",
+      "dev": true
+    },
     "@types/is-windows": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
+      "dev": true
+    },
+    "@types/isomorphic-fetch": {
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz",
+      "integrity": "sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==",
       "dev": true
     },
     "@types/json5": {
@@ -3922,15 +5521,16 @@
       }
     },
     "@types/koa": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.3.tgz",
-      "integrity": "sha512-ABxVkrNWa4O/Jp24EYI/hRNqEVRlhB9g09p48neQp4m3xL1TJtdWk2NyNQSMCU45ejeELMQZBYyfstyVvO2H3Q==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.4.tgz",
+      "integrity": "sha512-Etqs0kdqbuAsNr5k6mlZQelpZKVwMu9WPRHVVTLnceZlhr0pYmblRNJbCgoCMzKWWePldydU0AYEOX4Q9fnGUQ==",
       "dev": true,
       "requires": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
         "@types/cookies": "*",
         "@types/http-assert": "*",
+        "@types/http-errors": "*",
         "@types/keygrip": "*",
         "@types/koa-compose": "*",
         "@types/node": "*"
@@ -3993,6 +5593,12 @@
         "@types/koa": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.160",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.160.tgz",
+      "integrity": "sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA==",
+      "dev": true
+    },
     "@types/lru-cache": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
@@ -4000,9 +5606,9 @@
       "dev": true
     },
     "@types/mime": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
-      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
       "dev": true
     },
     "@types/minimatch": {
@@ -4023,10 +5629,20 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
       "dev": true
     },
+    "@types/n3": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.4.4.tgz",
+      "integrity": "sha512-xsWfwyDh0uAH0CXvwqe9vb2UEDafMjRez/pB7yZwbWpd9Olw2wdxaL32FtdHjmmFE6b9i+j249JfRyZnvWkoqg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/rdf-js": "*"
+      }
+    },
     "@types/node": {
-      "version": "14.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
-      "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.1.tgz",
+      "integrity": "sha512-HnYlg/BRF8uC1FyKRFZwRaCPTPYKa+6I8QiUZFLredaGOou481cgFS4wKRFyKvQtX8xudqkSdBczJHIYSQYKrQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -4039,6 +5655,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "@types/parse-link-header": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-1.0.0.tgz",
+      "integrity": "sha512-fCA3btjE7QFeRLfcD0Sjg+6/CnmC66HpMBoRfRzd2raTaWMJV21CCZ0LO8MOqf8onl5n0EPfjq4zDhbyX8SVwA==",
       "dev": true
     },
     "@types/parse5": {
@@ -4072,9 +5694,9 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA==",
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==",
       "dev": true
     },
     "@types/range-parser": {
@@ -4082,6 +5704,15 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
+    },
+    "@types/rdf-js": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-3.0.3.tgz",
+      "integrity": "sha512-1dvodNHh/YpLovHA/b046Nu+xERVt0KcYJFQH1A8S4ZcMj+stYtx4ypXw0X2/oatbREUo4JW+cjoBll3CVtwSQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/relateurl": {
       "version": "0.2.28",
@@ -4108,9 +5739,9 @@
       }
     },
     "@types/serve-static": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
-      "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
+      "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
       "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
@@ -4118,9 +5749,9 @@
       }
     },
     "@types/sinon": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.4.tgz",
-      "integrity": "sha512-sJmb32asJZY6Z2u09bl0G2wglSxDlROlAejCjsnor+LzBMz17gu8IU7vKC/vWDnv9zEq2wqADHVXFjf4eE8Gdw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.5.tgz",
+      "integrity": "sha512-4CnkGdM/5/FXDGqL32JQ1ttVrGvhOoesLLF7VnTh4KdjK5N5VQOtxaylFqqTjnHx55MnD9O02Nbk5c1ELC8wlQ==",
       "dev": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
@@ -4142,6 +5773,15 @@
       "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
       "dev": true
     },
+    "@types/sparqljs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.0.1.tgz",
+      "integrity": "sha512-2SGl+Q4Gq0Rh/y0ZT6iBvQDDlws3NiPKfkMaEnGDWHvwNonlSZt03jm7HJ7C9I+huwBQ5l5SOYpeJsrh0nOJew==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "*"
+      }
+    },
     "@types/uglify-js": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
@@ -4159,10 +5799,31 @@
         }
       }
     },
+    "@types/uritemplate": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uritemplate/-/uritemplate-0.3.4.tgz",
+      "integrity": "sha512-1D8mJEeQEXynoPQKJkneIK+tXaM2Qnk6c80RBQPV/O2ToypI4mlqXy5jojnYKjTX2Q+EMNMOWt0wNdLbb2MUpA==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "dev": true
+    },
     "@types/whatwg-url": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
       "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/xml": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/xml/-/xml-1.0.5.tgz",
+      "integrity": "sha512-h3PVM7waRi2UeoaY2BhpLGvettU/3vfCbsjXMV/9Ex5WjvIy82J8Qfp1xiPxM4kTSOLdFFpjRwQ7YY7XJeKBvg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -4252,9 +5913,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -4263,38 +5924,38 @@
       }
     },
     "@wdio/protocols": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.3.0.tgz",
-      "integrity": "sha512-1GKzfyCTLW5WkFd3W7NLACih+zNWU7c8kFurbCQXDK1ko1obqJEs7ZjBr85q5XqMWburdks5rDjyml2iEB2LBg==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.3.6.tgz",
+      "integrity": "sha512-cocBRkv5sYUBxXResuxskQhIkKgDgE/yAtgMGR5wXLrtG/sMpZ2HVy6LOcOeARidAaRwbav80M2ZHjTCjPn53w==",
       "dev": true
     },
     "@wdio/repl": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.3.0.tgz",
-      "integrity": "sha512-FT3flKOqNdZNG1uYl+QpOfdZIgKAWhLfoQ0s+wL0crLeDNIFvvM2qSDhRBRDYV7a0IFyBi8Z975WBn0dlH03Ig==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.4.0.tgz",
+      "integrity": "sha512-3oSRBzbWM67kng/ZqcDtFTHhTVO/fIALNqfyEEzaMb7oJ2OXgibBzjEa1r8ZhKIC8TpEAJ29BdSll4brHUhQrw==",
       "dev": true,
       "requires": {
-        "@wdio/utils": "6.3.0"
+        "@wdio/utils": "6.4.0"
       }
     },
     "@wdio/utils": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.3.0.tgz",
-      "integrity": "sha512-PbeC5fpieamgSAHf7S58MAyraGU1qKxnHdfGMG+ZIWiIo73oo4j/57CcH6ZawQ3YC1wEc/5q+VXg7N5hvqhJOQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.4.0.tgz",
+      "integrity": "sha512-sAVBbgQjUmvbvkQ/EyWIUSDoebtiZewmf6wb6Pt6EZfaTm4hul30Txd+IXfazhuxp701PskwufkMWzrQIXhpKw==",
       "dev": true,
       "requires": {
         "@wdio/logger": "6.0.16"
       }
     },
     "@webcomponents/shadycss": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.0.tgz",
-      "integrity": "sha512-UMS+dF4DXDrcUmQqK6aLd/3mFyfGktKG/hZR6FtrsQK/INO07G0H8FxElLkuvHj0iePeZGpR7R4lWFTvX7rc9g=="
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.1.tgz",
+      "integrity": "sha512-XEVDA7oH6o4Au9apyRDucjcIzvP44Ur4sqTMGRKCcE6sCAeKiOkRE03TCYNJAFkzckMWWT8Xx3IxG3iwjAcsRQ=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.3.tgz",
-      "integrity": "sha512-cV4+sAmshf8ysU2USutrSRYQkJzEYKHsRCGa0CkMElGpG5747VHtkfsW3NdVIBV/m2MDKXTDydT4lkrysH7IFA==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.4.tgz",
+      "integrity": "sha512-UWXZYbaDLLfhm+xONXTiDciyhOSwKRrZieGQHFMSMGSxY4mbjZ5uYzOKgnuX0luYFvjJw32G3r0sCwQZPJIR4Q==",
       "dev": true
     },
     "JSONStream": {
@@ -4313,9 +5974,9 @@
       "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
     "abortcontroller-polyfill": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz",
-      "integrity": "sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz",
+      "integrity": "sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA==",
       "dev": true
     },
     "accepts": {
@@ -4329,9 +5990,9 @@
       }
     },
     "acorn": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -4353,9 +6014,9 @@
       "dev": true
     },
     "aggregate-error": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -4371,9 +6032,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -4389,13 +6050,13 @@
       "dev": true
     },
     "amf-client-js": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.1.3.tgz",
-      "integrity": "sha512-7SdySpL0t2rVKeJv8B6lf3JHF9iRWZLoYEDalCf4CB7coVx/nso2c6YihuszuDLh+sYRPw9ZI7MErJoh8GHBKQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.3.0.tgz",
+      "integrity": "sha512-fLRM3evsYnJOkJ5hRJO954/UvfcMbjm1YrEla/zTl6FY5RpTjYG4/YBSnBGnfOxZA5jPaKSG02RLPBQd2o910g==",
       "dev": true,
       "requires": {
         "ajv": "6.5.2",
-        "amf-shacl-node": "1.1.1"
+        "amf-shacl-node": "2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -4419,10 +6080,33 @@
       }
     },
     "amf-shacl-node": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/amf-shacl-node/-/amf-shacl-node-1.1.1.tgz",
-      "integrity": "sha512-CoW08R+Y5VluBhC0IT11yJMJqVfuYVa8JHKopL4sXXCgTjtKikn1dyfOmY/b/u0WVKmx787JVDb/HnTzOEVoiA==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/amf-shacl-node/-/amf-shacl-node-2.0.0.tgz",
+      "integrity": "sha512-38GcUBN7VFzpJHDWeEKZ5bcosGA1/Ur6egUrno+Uprgf/8aXeX0LumkG64sExQPrFQ649Ku3wfgWe+le4bUNVw==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-init-sparql-rdfjs": "^1.10.0",
+        "jsonld-streaming-serializer": "^1.1.0",
+        "lru-cache": "^6.0.0",
+        "n3": "^1.3.5"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
     },
     "ansi-colors": {
       "version": "3.2.3",
@@ -4513,18 +6197,18 @@
       }
     },
     "archiver": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-4.0.2.tgz",
-      "integrity": "sha512-B9IZjlGwaxF33UN4oPbfBkyA4V1SxNLeIhR1qY8sRXSsbdUkEHrrOvwlYFPx+8uQeCe9M+FG6KgO+imDmQ79CQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.0.tgz",
+      "integrity": "sha512-AEWhJz6Yi6hWtN1Sqy/H4sZo/lLMJ/NftXxGaDy/TnOMmmjsRaZc/Ts+U4BsPoBQkuunTN6t8hk7iU9A+HBxLw==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.0",
         "buffer-crc32": "^0.2.1",
-        "glob": "^7.1.6",
         "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
         "tar-stream": "^2.1.2",
-        "zip-stream": "^3.0.1"
+        "zip-stream": "^4.0.0"
       },
       "dependencies": {
         "async": {
@@ -4534,9 +6218,9 @@
           "dev": true
         },
         "bl": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-          "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
           "dev": true,
           "requires": {
             "buffer": "^5.5.0",
@@ -4687,6 +6371,12 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
+    "arrayify-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/arrayify-stream/-/arrayify-stream-1.0.0.tgz",
+      "integrity": "sha512-RP80ep76Lbew2wWN5ogrl2NluTnBVYYh2K3NNCcWfcmmUB7nBcNBctiJeEZAixp3I1vQ9H88iHZ9MbHSdkuupQ==",
+      "dev": true
+    },
     "arrify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
@@ -4741,11 +6431,35 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
+    "asynciterator": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.0.1.tgz",
+      "integrity": "sha512-i63IZ/CLbSwT+9+jezA8BFnMmmOylNN+2/yNqMSr37IdzjPLnYMfEvTOFt46hDA+san7k9CZN6gEzCgCTTfAWA==",
+      "dev": true
+    },
+    "asyncjoin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.0.1.tgz",
+      "integrity": "sha512-FjqqH7H9YUbE51U6xX4hQfzIAbyEKSZLdhdQNvl0kQ2vZvgiYgW1o1Vl4LJIU+3fu7ld3Tdcq72G5/h6OALsBw==",
+      "dev": true,
+      "requires": {
+        "asynciterator": "^3.0.0"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "asyncreiterable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/asyncreiterable/-/asyncreiterable-2.0.0.tgz",
+      "integrity": "sha512-Pq9wUkHrXshCxXWy4/O7krS9qGCgHxoDWajWJja/7f5KoZTcO5Xww25NSMTek+jL3CZ4GrHYvOHx5bmrR4nU3w==",
+      "dev": true,
+      "requires": {
+        "asynciterator": "^3.0.0"
+      }
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -4766,9 +6480,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
     },
     "axe-core": {
@@ -5044,9 +6758,9 @@
       "dev": true
     },
     "base64id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -5308,15 +7022,15 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
-      "integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.0.tgz",
+      "integrity": "sha512-pUsXKAF2lVwhmtpeA3LJrZ76jXuusrNyhduuQs7CDFf9foT4Y38aQOserd2lMe5DSSrjf3fx34oHwryuvxAUgQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001093",
-        "electron-to-chromium": "^1.3.488",
-        "escalade": "^3.0.1",
-        "node-releases": "^1.1.58"
+        "caniuse-lite": "^1.0.30001111",
+        "electron-to-chromium": "^1.3.523",
+        "escalade": "^3.0.2",
+        "node-releases": "^1.1.60"
       }
     },
     "browserslist-useragent": {
@@ -5604,9 +7318,15 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001102",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001102.tgz",
-      "integrity": "sha512-fOjqRmHjRXv1H1YD6QVLb96iKqnu17TjcLSaX64TwhGYed0P1E1CCWZ9OujbbK4Z/7zax7zAzvQidzdtjx8RcA==",
+      "version": "1.0.30001119",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001119.tgz",
+      "integrity": "sha512-Hpwa4obv7EGP+TjkCh/wVvbtNJewxmtg4yVJBLFnxo35vbPapBr138bUWENkb5j5L9JZJ9RXLn4OrXRG/cecPQ==",
+      "dev": true
+    },
+    "canonicalize": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.3.tgz",
+      "integrity": "sha512-QWAGweNicWIXzcl7skvUZQ/ArdecS8fOeudnjIU0LYqSdTOSBSap+0VPMas4u11cW3a9sN5AN/aJHQUGfdWLCw==",
       "dev": true
     },
     "capital-case": {
@@ -5799,9 +7519,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
-      "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -5839,6 +7559,16 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "class-utils": {
       "version": "0.3.6",
@@ -5967,52 +7697,23 @@
       }
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -6072,9 +7773,9 @@
       }
     },
     "codemirror": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.55.0.tgz",
-      "integrity": "sha512-TumikSANlwiGkdF/Blnu/rqovZ0Y3Jh8yy9TqrPbSM0xxSucq3RgnpVDQ+mD9q6JERJEIT2FMuF/fBGfkhIR/g=="
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.57.0.tgz",
+      "integrity": "sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg=="
     },
     "collapse-white-space": {
       "version": "1.0.6",
@@ -6246,16 +7947,70 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
+    "componentsjs": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-3.4.2.tgz",
+      "integrity": "sha512-ICaSvvxY/CvWwFt0lLsoRL/DHY09akoI6x9WakQQ9g4GYHVaZumWSAdOrzM/htjGpBumpVh1C/4hk0/ghh9jXA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "^4.14.56",
+        "@types/minimist": "^1.2.0",
+        "@types/n3": "0.0.3",
+        "@types/node": "8.10.21",
+        "global-modules": "^1.0.0",
+        "jsonld": "^0.4.11",
+        "lodash": "^4.17.4",
+        "minimist": "^1.2.0",
+        "n3": "^0.9.1",
+        "requireg": "^0.1.7"
+      },
+      "dependencies": {
+        "@types/n3": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/@types/n3/-/n3-0.0.3.tgz",
+          "integrity": "sha512-oqywrU7RdLKO0Ndnrue8smXR+oLW4EgFGrd/ewaYbkZjgr/eRpwpjsJk9D5Z8AF+cZKYbiQtR5BR6LNlLl0HPQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/node": {
+          "version": "8.10.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.21.tgz",
+          "integrity": "sha512-87XkD9qDXm8fIax+5y7drx84cXsu34ZZqfB7Cial3Q/2lxSoJ/+DRaWckkCbxP41wFSIrrb939VhzaNxj4eY1w==",
+          "dev": true
+        },
+        "n3": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/n3/-/n3-0.9.1.tgz",
+          "integrity": "sha1-QwtUfVjcc4FAjEV4TdgFgXGQOTI=",
+          "dev": true
+        }
+      }
+    },
     "compress-commons": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-3.0.0.tgz",
-      "integrity": "sha512-FyDqr8TKX5/X0qo+aVfaZ+PVmNJHJeckFBlq8jZGSJOgnynhfifoyl24qaqdUdDIBe0EVTHByN6NAkqYvE/2Xg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.1.tgz",
+      "integrity": "sha512-xZm9o6iikekkI0GnXCmAl3LQGZj5TBDj0zLowsqi7tJtEa3FMGSEcHcqrSJIrOAk1UG/NBbDn/F1q+MG/p/EsA==",
       "dev": true,
       "requires": {
         "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^3.0.1",
+        "crc32-stream": "^4.0.0",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^2.3.7"
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "compressible": {
@@ -6440,9 +8195,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "camelcase-keys": {
@@ -6454,14 +8209,6 @@
             "camelcase": "^5.3.1",
             "map-obj": "^4.0.0",
             "quick-lru": "^4.0.1"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
-            }
           }
         },
         "find-up": {
@@ -6496,18 +8243,16 @@
           "dev": true
         },
         "meow": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-          "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.0.tgz",
+          "integrity": "sha512-kq5F0KVteskZ3JdfyQFivJEj2RaA8NFsS4+r9DaMKLcUHpk5OcHS3Q0XkCXONB1mZRPsu/Y/qImKri0nwSEZog==",
           "dev": true,
           "requires": {
             "@types/minimist": "^1.2.0",
-            "arrify": "^2.0.1",
-            "camelcase": "^6.0.0",
             "camelcase-keys": "^6.2.2",
             "decamelize-keys": "^1.1.0",
             "hard-rejection": "^2.1.0",
-            "minimist-options": "^4.0.2",
+            "minimist-options": "4.1.0",
             "normalize-package-data": "^2.5.0",
             "read-pkg-up": "^7.0.1",
             "redent": "^3.0.0",
@@ -6541,14 +8286,14 @@
           "dev": true
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -6633,24 +8378,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
           "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
           "dev": true
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -6788,10 +8515,26 @@
         "safe-buffer": "^5.0.1"
       },
       "dependencies": {
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -6813,6 +8556,12 @@
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
+        },
+        "nested-error-stacks": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+          "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+          "dev": true
         }
       }
     },
@@ -6826,9 +8575,9 @@
       }
     },
     "crc32-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
-      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.0.tgz",
+      "integrity": "sha512-tyMw2IeUX6t9jhgXI6um0eKfWq4EIDpfv5m7GX4Jzp7eVelQ360xd8EPXJhp2mHwLQIkqlnMLjzqSZI3a+0wRw==",
       "dev": true,
       "requires": {
         "crc": "^3.4.4",
@@ -6846,6 +8595,28 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
+      "integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.0"
       }
     },
     "cross-spawn": {
@@ -6992,6 +8763,24 @@
         "nth-check": "^1.0.2"
       },
       "dependencies": {
+        "dom-serializer": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+          "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "entities": "^2.0.0"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+              "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+              "dev": true
+            }
+          }
+        },
         "domelementtype": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
@@ -7017,14 +8806,13 @@
       "dev": true
     },
     "css-selector-tokenizer": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.2.tgz",
-      "integrity": "sha512-yj856NGuAymN6r8bn8/Jl46pR+OC3eEvAhfGYDUe7YPtTPAYrSSw4oAniZ9Y8T5B92hjhwTBLUen0/vKPxf6pw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
+      "integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2",
-        "regexpu-core": "^4.6.0"
+        "fastparse": "^1.1.2"
       }
     },
     "css-tree": {
@@ -7246,6 +9034,12 @@
         "map-obj": "^1.0.0"
       }
     },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+      "dev": true
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -7430,6 +9224,12 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -7544,15 +9344,15 @@
       "dev": true
     },
     "devtools": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/devtools/-/devtools-6.3.3.tgz",
-      "integrity": "sha512-VHvJH7y2/pHtDzhXF8T9mlT5sqrUl2WSjCWhjvyohTyfMjtIu15p78lx3NowMwfo12N2/3riW9dVGeVOa6WILQ==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/devtools/-/devtools-6.4.4.tgz",
+      "integrity": "sha512-L9kfK/wkHWzBy0gvFmMmLyLzDgGbeVKk8bRwTZ3N99uo+Pt3IF6oBDjEPzE721dNzaO91/xVr5l97+Uo1eabMA==",
       "dev": true,
       "requires": {
         "@wdio/config": "6.1.14",
         "@wdio/logger": "6.0.16",
-        "@wdio/protocols": "6.3.0",
-        "@wdio/utils": "6.3.0",
+        "@wdio/protocols": "6.3.6",
+        "@wdio/utils": "6.4.0",
         "chrome-launcher": "^0.13.1",
         "puppeteer-core": "^5.1.0",
         "ua-parser-js": "^0.7.21",
@@ -7560,9 +9360,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.767361",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.767361.tgz",
-      "integrity": "sha512-ziRTdhEVQ9jEwedaUaXZ7kl9w9TF/7A3SXQ0XuqrJB+hMS62POHZUWTbumDN2ehRTfvWqTPc2Jw4gUl/jggmHA==",
+      "version": "0.0.781568",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.781568.tgz",
+      "integrity": "sha512-9Uqnzy6m6zEStluH9iyJ3iHyaQziFnMnLeC8vK0eN6smiJmIx7+yB64d67C2lH/LZra+5cGscJAJsNXO+MdPMg==",
       "dev": true
     },
     "di": {
@@ -7661,12 +9461,13 @@
       }
     },
     "dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.0.1.tgz",
+      "integrity": "sha512-1Aj1Qy3YLbdslkI75QEOfdp9TkQ3o8LRISAzxOibjBs/xWwr1WxZFOQphFkZuepHFGo+kB8e5FVJSS0faAJ4Rw==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
+        "domhandler": "^3.0.0",
         "entities": "^2.0.0"
       }
     },
@@ -7705,17 +9506,17 @@
       }
     },
     "dompurify": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.12.tgz",
-      "integrity": "sha512-Fl8KseK1imyhErHypFPA8qpq9gPzlsJ/EukA6yk9o0gX23p1TzC+rh9LqNg1qvErRTc0UNMYlKxEGSfSh43NDg=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.14.tgz",
+      "integrity": "sha512-oqcjyCLHLjWugZ6VwK0YfmRND/DFy/CuZhdasmymMfnxbzaaQxBSA1ATZIXWESGDj/nvq1vKLmRa7rTdbGgrmQ=="
     },
     "domutils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.1.0.tgz",
-      "integrity": "sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.2.0.tgz",
+      "integrity": "sha512-0haAxVr1PR0SqYwCH7mxMpHZUwjih9oPPedqpR/KufsnxPyZ9dyVw1R5093qnJF3WXSbjBkdzRWLw/knJV/fAg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "^0.2.1",
+        "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
         "domhandler": "^3.0.0"
       }
@@ -7872,9 +9673,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.499",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.499.tgz",
-      "integrity": "sha512-y7FwtQm/8xuLMnYQfBQDYzCpNn+VkSnf4c3Km5TWMNXg7JA5RQBuxmcLaKdDVcIK0K5xGIa7TlxpRt4BdNxNoA==",
+      "version": "1.3.554",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.554.tgz",
+      "integrity": "sha512-Vtz2dVH5nMtKK4brahmgScwFS8PBnpA4VObYXtlsqN8ZpT9IFelv0Rpflc1+NIILjGVaj6vEiXQbhrs3Pl8O7g==",
       "dev": true
     },
     "emoji-regex": {
@@ -7895,6 +9696,26 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -7905,76 +9726,59 @@
       }
     },
     "engine.io": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
-      "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.2.tgz",
+      "integrity": "sha512-b4Q85dFkGw+TqgytGPrGgACRUhsdKc9S9ErRAXpPGy/CXKs4tYoHDkvIRdsseAF7NjfVwjRFIn6KTnbw7LwJZg==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
-        "base64id": "1.0.0",
+        "base64id": "2.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
+        "debug": "~4.1.0",
+        "engine.io-parser": "~2.2.0",
+        "ws": "^7.1.2"
       }
     },
     "engine.io-client": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-      "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
+      "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
+        "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "~4.1.0",
+        "engine.io-parser": "~2.2.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
+        "ws": "~6.1.0",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+          "dev": true
+        },
+        "ws": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "async-limiter": "~1.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
     "engine.io-parser": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
-      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
+      "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
       "dev": true,
       "requires": {
         "after": "0.8.2",
@@ -8042,24 +9846,24 @@
       }
     },
     "es-dev-server": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.56.1.tgz",
-      "integrity": "sha512-mcTwrKzyIQNLJUUnQptmVS/1Qdfr4ZcNOyHvWCidQUQQcYOlpnfXpUhcGvaYCNKNwii69uKui1WVixLO1c+OEw==",
+      "version": "1.57.4",
+      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.57.4.tgz",
+      "integrity": "sha512-GNstq4VeNmkon9W4dABCC3e3540cWVmhsnO4d8axBSgk0D4HQH/t2NqM4o9Qvq4/z9NMAqW1CazmvuFdl8oqKg==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.9.0",
-        "@babel/plugin-proposal-dynamic-import": "^7.8.3",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-proposal-optional-chaining": "^7.9.0",
+        "@babel/core": "^7.11.1",
+        "@babel/plugin-proposal-dynamic-import": "^7.10.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.11.0",
         "@babel/plugin-syntax-class-properties": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
         "@babel/plugin-syntax-numeric-separator": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-transform-template-literals": "^7.8.3",
         "@babel/preset-env": "^7.9.0",
         "@koa/cors": "^3.1.0",
-        "@open-wc/building-utils": "^2.18.0",
+        "@open-wc/building-utils": "^2.18.1",
         "@rollup/plugin-node-resolve": "^7.1.1",
         "@rollup/pluginutils": "^3.0.0",
         "@types/babel__core": "^7.1.3",
@@ -8103,7 +9907,7 @@
         "open": "^7.0.3",
         "parse5": "^5.1.1",
         "path-is-inside": "^1.0.2",
-        "polyfills-loader": "^1.6.1",
+        "polyfills-loader": "^1.7.1",
         "portfinder": "^1.0.21",
         "rollup": "^2.7.2",
         "strip-ansi": "^5.2.0",
@@ -8163,6 +9967,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+      "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
       "dev": true
     },
     "escalade": {
@@ -8366,9 +10176,9 @@
       }
     },
     "eslint-plugin-html": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-6.0.2.tgz",
-      "integrity": "sha512-Ik/z32UteKLo8GEfwNqVKcJ/WOz/be4h8N5mbMmxxnZ+9aL9XczOXQFz/bGu+nAGVoRg8CflldxJhONFpqlrxw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-6.0.3.tgz",
+      "integrity": "sha512-1KV2ebQHywlXkfpXOGjxuEyoq+g6AWvD6g9TB28KsGhbM5rJeHXAEpHOev6LqZv6ylcfa9BWokDsNVKyYefzGw==",
       "dev": true,
       "requires": {
         "htmlparser2": "^4.1.0"
@@ -8490,9 +10300,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
           "dev": true
         }
       }
@@ -8531,9 +10341,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "execa": {
@@ -8649,6 +10459,15 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "express": {
@@ -9042,6 +10861,24 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-sparql-endpoint": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-1.6.2.tgz",
+      "integrity": "sha512-d0nTwXc6BBnQdrmx7+Bk6pLJ5MLzJtYJRNq4YSpL4Bym8hd12RaBUL7OkcxtuFaMY9gG2Mw0JVNMZeF3bjVSBg==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "isomorphic-fetch": "^2.2.1",
+        "minimist": "^1.2.0",
+        "n3": "^1.0.0",
+        "rdf-string": "^1.3.1",
+        "sparqljs": "^3.0.0",
+        "sparqljson-parse": "^1.5.0",
+        "sparqlxml-parse": "^1.2.0",
+        "stream-to-string": "^1.1.0",
+        "web-streams-node": "^0.4.0"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -9207,9 +11044,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
-      "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
       "dev": true
     },
     "for-in": {
@@ -9405,9 +11242,9 @@
       "dev": true
     },
     "get-stream": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
@@ -9442,9 +11279,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "camelcase-keys": {
@@ -9456,14 +11293,6 @@
             "camelcase": "^5.3.1",
             "map-obj": "^4.0.0",
             "quick-lru": "^4.0.1"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
-            }
           }
         },
         "find-up": {
@@ -9498,18 +11327,16 @@
           "dev": true
         },
         "meow": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-          "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.0.tgz",
+          "integrity": "sha512-kq5F0KVteskZ3JdfyQFivJEj2RaA8NFsS4+r9DaMKLcUHpk5OcHS3Q0XkCXONB1mZRPsu/Y/qImKri0nwSEZog==",
           "dev": true,
           "requires": {
             "@types/minimist": "^1.2.0",
-            "arrify": "^2.0.1",
-            "camelcase": "^6.0.0",
             "camelcase-keys": "^6.2.2",
             "decamelize-keys": "^1.1.0",
             "hard-rejection": "^2.1.0",
-            "minimist-options": "^4.0.2",
+            "minimist-options": "4.1.0",
             "normalize-package-data": "^2.5.0",
             "read-pkg-up": "^7.0.1",
             "redent": "^3.0.0",
@@ -9543,14 +11370,14 @@
           "dev": true
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -9635,24 +11462,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
           "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
           "dev": true
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -9715,6 +11524,30 @@
       "dev": true,
       "requires": {
         "ini": "^1.3.4"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -9782,9 +11615,9 @@
       }
     },
     "got": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.5.1.tgz",
-      "integrity": "sha512-reQEZcEBMTGnujmQ+Wm97mJs/OK6INtO6HmLI+xt3+9CvnRwWjXutUvb2mqr+Ao4Lu05Rx6+udx9sOQAmExMxA==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.5.2.tgz",
+      "integrity": "sha512-yUhpEDLeuGiGJjRSzEq3kvt4zJtAcjKmhIiwNp/eUs75tRlXfWcHo5tcBaMQtnjHWC7nQYT5HkY/l0QOQTkVww==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^3.0.0",
@@ -9801,9 +11634,9 @@
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.0.0.tgz",
-          "integrity": "sha512-kqA5I6Yun7PBHk8WN9BBP1c7FfN2SrD05GuVSEYPqDb4nerv7HqYfgBfMIKmT/EuejURkJKLZuLyGKGs6WEG9w==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
+          "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
           "dev": true
         },
         "cacheable-request": {
@@ -9892,17 +11725,55 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
     "grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
+    },
+    "graphql": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+      "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==",
+      "dev": true
+    },
+    "graphql-ld": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-ld/-/graphql-ld-1.1.0.tgz",
+      "integrity": "sha512-nYfXYhpJMuWLTJ1q4fu64Y59OYVR2xQCJcPMEgzYEDEArUIyyEOi8l+VeL/ttBZVg47RICiiC3e26qRYwBR+kQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^2.0.11",
+        "graphql-to-sparql": "^2.1.0",
+        "jsonld-context-parser": "^2.0.0",
+        "sparqlalgebrajs": "^2.2.1",
+        "sparqljson-to-tree": "^2.0.0"
+      },
+      "dependencies": {
+        "@types/rdf-js": {
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.12.tgz",
+          "integrity": "sha512-NBzHFHp2vHOJkPlSqzsOrkEsD9grKn+PdFjZieIw59pc0FlRG6WEQAjQZvHzFxJlYzC6ZDCFyTA1wBvUnnzUQw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
+    },
+    "graphql-to-sparql": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-2.1.1.tgz",
+      "integrity": "sha512-o+bnwrL4ugil/A4a+x/C8Yae+irxm3xLQGXWrjc5p9K2KEiforY4bU8Ed6Q/wasFjeublCp2v0xEFDnUxyY40g==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^3.0.0",
+        "graphql": "^15.0.0",
+        "jsonld-context-parser": "^2.0.0",
+        "minimist": "^1.2.0",
+        "sparqlalgebrajs": "^2.0.0"
+      }
     },
     "growl": {
       "version": "1.10.5",
@@ -9917,12 +11788,12 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
     },
@@ -10065,6 +11936,36 @@
         }
       }
     },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
     "hash.js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -10096,6 +11997,15 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -10248,6 +12158,12 @@
           "dev": true
         }
       }
+    },
+    "http-link-header": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.2.tgz",
+      "integrity": "sha512-z6YOZ8ZEnejkcCWlGZzYXNa6i+ZaTfiTg3WhlV/YvnNya3W/RbX1bMVUMTuCrg/DrtTCQxaFCkXCz4FtLpcebg==",
+      "dev": true
     },
     "http-proxy": {
       "version": "1.18.1",
@@ -10413,14 +12329,14 @@
           "dev": true
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -10446,9 +12362,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -10481,6 +12397,12 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
       "dev": true
     },
     "import-cwd": {
@@ -10581,9 +12503,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.2.tgz",
-      "integrity": "sha512-DF4osh1FM6l0RJc5YWYhSDB6TawiBRlbV9Cox8MWlidU218Tb7fm3lQTULyUJDfJ0tjbzl0W4q651mrCCEM55w==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -10592,7 +12514,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.16",
+        "lodash": "^4.17.19",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.6.0",
@@ -10652,9 +12574,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -10843,9 +12765,9 @@
       "dev": true
     },
     "is-docker": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
       "dev": true
     },
     "is-extendable": {
@@ -10945,9 +12867,9 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
@@ -11073,6 +12995,34 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -11098,6 +13048,87 @@
         "make-dir": "^2.1.0",
         "minimatch": "^3.0.4",
         "once": "^1.4.0"
+      },
+      "dependencies": {
+        "istanbul-lib-report": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+          "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^2.0.5",
+            "make-dir": "^2.1.0",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+          "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^2.0.5",
+            "make-dir": "^2.1.0",
+            "rimraf": "^2.6.3",
+            "source-map": "^0.6.1"
+          }
+        },
+        "istanbul-reports": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+          "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
+          "dev": true,
+          "requires": {
+            "html-escaper": "^2.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "istanbul-lib-coverage": {
@@ -11131,48 +13162,55 @@
       }
     },
     "istanbul-lib-report": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+          "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+          "dev": true
+        },
         "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
+        "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
       },
       "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
+        "istanbul-lib-coverage": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+          "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
@@ -11183,12 +13221,13 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
-      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
       "dev": true,
       "requires": {
-        "html-escaper": "^2.0.0"
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
       }
     },
     "isurl": {
@@ -11268,6 +13307,12 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz",
+      "integrity": "sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -11316,6 +13361,77 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonld": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-0.4.12.tgz",
+      "integrity": "sha1-oC8gXVNBQU3xtthBTxuWenEgc+g=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^2.0.0",
+        "pkginfo": "~0.4.0",
+        "request": "^2.61.0",
+        "xmldom": "0.1.19"
+      }
+    },
+    "jsonld-context-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.0.2.tgz",
+      "integrity": "sha512-IjQi26E+5ESS85MkcLsYo9gV93oJSOvQ/deHxKspaeHOmRiPyRRaGAk86DjuQc6c0hdp3OKGvDDsy3wi8znsqg==",
+      "dev": true,
+      "requires": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/isomorphic-fetch": "^0.0.35",
+        "@types/node": "^13.1.0",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "isomorphic-fetch": "^2.2.1",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
+          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+          "dev": true
+        }
+      }
+    },
+    "jsonld-streaming-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.0.2.tgz",
+      "integrity": "sha512-h4cK+PQMvOHd+UqgAFpKBmt5LWYoQMQLu9PP7YsRP7rnSJbU/EfJFcJFG6/sdtZslQ6dlNwOvfHbjQ9clzZPzg==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.2",
+        "@types/http-link-header": "^1.0.1",
+        "@types/rdf-js": "^3.0.0",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.0.1",
+        "jsonparse": "^1.3.1"
+      }
+    },
+    "jsonld-streaming-serializer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-1.1.0.tgz",
+      "integrity": "sha512-C+cs913C3XDScZIqUL8fg5crHQtPTQSZstzvFmhA9/r0QBCRw88BR4TYHvLNhJhzB45GOpoF5/Fx4I4xfKGpOQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^2.0.1",
+        "jsonld-context-parser": "^2.0.0"
+      },
+      "dependencies": {
+        "@types/rdf-js": {
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.12.tgz",
+          "integrity": "sha512-NBzHFHp2vHOJkPlSqzsOrkEsD9grKn+PdFjZieIw59pc0FlRG6WEQAjQZvHzFxJlYzC6ZDCFyTA1wBvUnnzUQw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
+    },
     "jsonlint": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.3.tgz",
@@ -11350,9 +13466,9 @@
       }
     },
     "jsrsasign": {
-      "version": "8.0.20",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.20.tgz",
-      "integrity": "sha512-JTXt9+nqdynIB8wFsS6e8ffHhIjilhywXwdaEVHSj9OVmwldG2H0EoCqkQ+KXkm2tVqREfH/HEmklY4k1/6Rcg=="
+      "version": "8.0.24",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.24.tgz",
+      "integrity": "sha512-u45jAyusqUpyGbFc2IbHoeE4rSkoBWQgLe/w99temHenX+GyCz4nflU5sjK7ajU1ffZTezl6le7u43Yjr/lkQg=="
     },
     "just-extend": {
       "version": "4.1.0",
@@ -11361,55 +13477,65 @@
       "dev": true
     },
     "karma": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-4.4.1.tgz",
-      "integrity": "sha512-L5SIaXEYqzrh6b1wqYC42tNsFMx2PWuxky84pK9coK09MvmL7mxii3G3bZBh/0rvD27lqDd0le9jyhzvwif73A==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-5.1.1.tgz",
+      "integrity": "sha512-xAlOr5PMqUbiKXSv5PCniHWV3aiwj6wIZ0gUVcwpTCPVQm/qH2WAMFWxtnpM6KJqhkRWrIpovR4Rb0rn8GtJzQ==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.3.0",
-        "body-parser": "^1.16.1",
+        "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.0.0",
-        "colors": "^1.1.0",
-        "connect": "^3.6.0",
+        "colors": "^1.4.0",
+        "connect": "^3.7.0",
         "di": "^0.0.1",
-        "dom-serialize": "^2.2.0",
-        "flatted": "^2.0.0",
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "http-proxy": "^1.13.0",
-        "isbinaryfile": "^3.0.0",
-        "lodash": "^4.17.14",
-        "log4js": "^4.0.0",
-        "mime": "^2.3.1",
-        "minimatch": "^3.0.2",
-        "optimist": "^0.6.1",
-        "qjobs": "^1.1.4",
-        "range-parser": "^1.2.0",
-        "rimraf": "^2.6.0",
-        "safe-buffer": "^5.0.1",
-        "socket.io": "2.1.1",
+        "dom-serialize": "^2.2.1",
+        "flatted": "^2.0.2",
+        "glob": "^7.1.6",
+        "graceful-fs": "^4.2.4",
+        "http-proxy": "^1.18.1",
+        "isbinaryfile": "^4.0.6",
+        "lodash": "^4.17.15",
+        "log4js": "^6.2.1",
+        "mime": "^2.4.5",
+        "minimatch": "^3.0.4",
+        "qjobs": "^1.2.0",
+        "range-parser": "^1.2.1",
+        "rimraf": "^3.0.2",
+        "socket.io": "^2.3.0",
         "source-map": "^0.6.1",
-        "tmp": "0.0.33",
-        "useragent": "2.3.0"
+        "tmp": "0.2.1",
+        "ua-parser-js": "0.7.21",
+        "yargs": "^15.3.1"
       },
       "dependencies": {
-        "isbinaryfile": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-          "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+        "date-format": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+          "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
-            "buffer-alloc": "^1.2.0"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+        "log4js": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
+          "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "date-format": "^3.0.0",
+            "debug": "^4.1.1",
+            "flatted": "^2.0.1",
+            "rfdc": "^1.1.4",
+            "streamroller": "^2.2.4"
           }
         },
         "source-map": {
@@ -11418,13 +13544,23 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
-        "tmp": {
-          "version": "0.0.33",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+        "streamroller": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+          "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "~1.0.2"
+            "date-format": "^2.1.0",
+            "debug": "^4.1.1",
+            "fs-extra": "^8.1.0"
+          },
+          "dependencies": {
+            "date-format": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+              "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+              "dev": true
+            }
           }
         }
       }
@@ -11436,6 +13572,40 @@
       "dev": true,
       "requires": {
         "which": "^1.2.1"
+      }
+    },
+    "karma-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.0.3.tgz",
+      "integrity": "sha512-atDvLQqvPcLxhED0cmXYdsPMCQuh6Asa9FMZW1bhNqlVEhJoB9qyZ2BY1gu7D/rr5GLGb5QzYO4siQskxaWP/g==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.1",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "istanbul-lib-coverage": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+          "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+          "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.7.5",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "semver": "^6.3.0"
+          }
+        }
       }
     },
     "karma-coverage-istanbul-reporter": {
@@ -11786,20 +13956,20 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "10.2.11",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.2.11.tgz",
-      "integrity": "sha512-LRRrSogzbixYaZItE2APaS4l2eJMjjf5MbclRZpLJtcQJShcvUzKXsNeZgsLIZ0H0+fg2tL4B59fU9wHIHtFIA==",
+      "version": "10.2.13",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.2.13.tgz",
+      "integrity": "sha512-conwlukNV6aL9SiMWjFtDp5exeDnTMekdNPDZsKGnpfQuHcO0E3L3Bbf58lcR+M7vk6LpCilxDAVks/DDVBYlA==",
       "dev": true,
       "requires": {
-        "chalk": "^4.0.0",
-        "cli-truncate": "2.1.0",
-        "commander": "^5.1.0",
-        "cosmiconfig": "^6.0.0",
+        "chalk": "^4.1.0",
+        "cli-truncate": "^2.1.0",
+        "commander": "^6.0.0",
+        "cosmiconfig": "^7.0.0",
         "debug": "^4.1.1",
         "dedent": "^0.7.0",
-        "enquirer": "^2.3.5",
-        "execa": "^4.0.1",
-        "listr2": "^2.1.0",
+        "enquirer": "^2.3.6",
+        "execa": "^4.0.3",
+        "listr2": "^2.6.0",
         "log-symbols": "^4.0.0",
         "micromatch": "^4.0.2",
         "normalize-path": "^3.0.0",
@@ -11844,22 +14014,22 @@
           "dev": true
         },
         "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
+          "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
           "dev": true
         },
         "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
           "dev": true,
           "requires": {
             "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
+            "import-fresh": "^3.2.1",
             "parse-json": "^5.0.0",
             "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
+            "yaml": "^1.10.0"
           }
         },
         "cross-spawn": {
@@ -11915,14 +14085,14 @@
           }
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -11954,9 +14124,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -11980,18 +14150,18 @@
       "dev": true
     },
     "listr2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-2.2.0.tgz",
-      "integrity": "sha512-Q8qbd7rgmEwDo1nSyHaWQeztfGsdL6rb4uh7BA+Q80AZiDET5rVntiU1+13mu2ZTDVaBVbvAD1Db11rnu3l9sg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-2.6.1.tgz",
+      "integrity": "sha512-1aPX9GkS+W0aHfPUDedJqeqj0DOe1605NaNoqdwEYw/UF2UbZgCIIMpXXZALeG/8xzwMBztguzQEubU5Xw1Qbw==",
       "dev": true,
       "requires": {
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.0",
         "cli-truncate": "^2.1.0",
         "figures": "^3.2.0",
         "indent-string": "^4.0.0",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
-        "rxjs": "^6.5.5",
+        "rxjs": "^6.6.2",
         "through": "^2.3.8"
       },
       "dependencies": {
@@ -12043,9 +14213,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -12054,17 +14224,17 @@
       }
     },
     "lit-element": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.3.1.tgz",
-      "integrity": "sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
+      "integrity": "sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==",
       "requires": {
         "lit-html": "^1.1.1"
       }
     },
     "lit-html": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
-      "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
+      "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -12100,9 +14270,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -12212,6 +14382,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "lodash.uniqwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+      "integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM=",
       "dev": true
     },
     "lodash.zip": {
@@ -12324,26 +14500,6 @@
             "astral-regex": "^2.0.0",
             "is-fullwidth-code-point": "^3.0.0"
           }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
         }
       }
     },
@@ -12361,9 +14517,9 @@
       }
     },
     "loglevel": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
-      "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
+      "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
       "dev": true
     },
     "loglevel-plugin-prefix": {
@@ -12422,27 +14578,12 @@
       }
     },
     "make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "requires": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "semver": "^6.0.0"
       }
     },
     "map-cache": {
@@ -12498,6 +14639,17 @@
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         }
+      }
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "mdn-data": {
@@ -12785,6 +14937,12 @@
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -12793,6 +14951,12 @@
           "requires": {
             "color-convert": "^1.9.0"
           }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
         },
         "chalk": {
           "version": "2.4.2",
@@ -12816,6 +14980,17 @@
             }
           }
         },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -12824,6 +14999,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "find-up": {
           "version": "3.0.0",
@@ -12847,6 +15028,12 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "js-yaml": {
           "version": "3.13.1",
@@ -12916,6 +15103,26 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -12929,6 +15136,45 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -12972,6 +15218,29 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "n3": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.2.tgz",
+      "integrity": "sha512-9R45WRNxNPblKLbXGwR9IvtaVvdr80vRxME79fhWnqBzHb2GcP6lS77Mvf8Fx6Wpfn8PpBTdggceWsSMDGY/SA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -12997,6 +15266,12 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "negotiate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/negotiate/-/negotiate-1.0.1.tgz",
+      "integrity": "sha1-NayLVnL3sF+qEL8CYTQusRIDcP0=",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -13004,9 +15279,9 @@
       "dev": true
     },
     "nested-error-stacks": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
+      "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "dev": true
     },
     "nice-try": {
@@ -13088,9 +15363,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.59",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
-      "integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw==",
+      "version": "1.1.60",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
+      "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
       "dev": true
     },
     "nomnom": {
@@ -13318,9 +15593,9 @@
       }
     },
     "onetime": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
@@ -13333,9 +15608,9 @@
       "dev": true
     },
     "open": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
-      "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.2.1.tgz",
+      "integrity": "sha512-xbYCJib4spUdmcs0g/2mK1nKo/jO2T7INClWd/beL7PFkXRWgr8B23ssDHX/USPn2M2IjDR5UdpYs6I67SnTSA==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -13450,9 +15725,9 @@
       }
     },
     "p-queue": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.5.0.tgz",
-      "integrity": "sha512-FLaTTD9Am6TeDfNuN0d+INeyVJoICoBS+OVP5K1S84v4w51LN3nRkCT+WC7xLBepV2s+N4LibM7Ys7xcSc0+1A==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.1.tgz",
+      "integrity": "sha512-miQiSxLYPYBxGkrldecZC18OTLjdUqnlRebGzPRiVxB8mco7usCmm7hFuxiTvp93K18JnLtE4KMMycjAu/cQQg==",
       "dev": true,
       "requires": {
         "eventemitter3": "^4.0.4",
@@ -13525,6 +15800,21 @@
       "requires": {
         "error-ex": "^1.2.0"
       }
+    },
+    "parse-link-header": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
+      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "dev": true,
+      "requires": {
+        "xtend": "~4.0.1"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parse5": {
       "version": "5.1.1",
@@ -13708,6 +15998,12 @@
         "find-up": "^2.1.0"
       }
     },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+      "dev": true
+    },
     "please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -13718,13 +16014,13 @@
       }
     },
     "polyfills-loader": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.6.1.tgz",
-      "integrity": "sha512-GK3jZGLy9nApfRYfHrrO4RYkBkpjiXUVWVdp169g4Y8HV+ZazrGQX46tNpbwP0dtrgHgADyJvZYPfdFuooHy5Q==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.7.1.tgz",
+      "integrity": "sha512-+cClGOZNQtWVedt2a2Ku9r6ejfnhQFbuaSPtlaGLl2R9ESWaJNoq8r29d0BTpAgrEX/xXsoh2YHgamNugW6Ahw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.9.0",
-        "@open-wc/building-utils": "^2.18.0",
+        "@babel/core": "^7.11.1",
+        "@open-wc/building-utils": "^2.18.1",
         "@webcomponents/webcomponentsjs": "^2.4.0",
         "abortcontroller-polyfill": "^1.4.0",
         "core-js-bundle": "^3.6.0",
@@ -13882,14 +16178,14 @@
       }
     },
     "portfinder": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
-      "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
         "debug": "^3.1.1",
-        "mkdirp": "^0.5.1"
+        "mkdirp": "^0.5.5"
       },
       "dependencies": {
         "debug": {
@@ -13969,9 +16265,9 @@
       }
     },
     "postcss-calc": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.2.tgz",
-      "integrity": "sha512-rofZFHUg6ZIrvRwPeFktv06GdbDYLcGqh9EwiMutZg+a0oePCCw1zHOEiji6LCpyRcjTREtPASuUqeAvYlEVvQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.3.tgz",
+      "integrity": "sha512-IB/EAEmZhIMEIhG7Ov4x+l47UaXOS1n2f4FBUk/aKllQhtSCxWhTzn0nJgkqN7fo/jcWySvWTSB6Syk9L+31bA==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.27",
@@ -14753,9 +17049,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
-      "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+      "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -14770,6 +17066,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc=",
       "dev": true
     },
     "promise.series": {
@@ -14829,13 +17131,13 @@
       "dev": true
     },
     "puppeteer-core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.2.0.tgz",
-      "integrity": "sha512-+gG1mW4ve7e4f1H18KWyEdbSc5Sb9+zxGBlb6CCclCf5rDsuPhYubTfOWJZB4L759D4XDtf04GOp+lmTmd61Nw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.2.1.tgz",
+      "integrity": "sha512-gLjEOrzwgcnwRH+sm4hS1TBqe2/DN248nRb2hYB7+lZ9kCuLuACNvuzlXILlPAznU3Ob+mEvVEBDcLuFa0zq3g==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.767361",
+        "devtools-protocol": "0.0.781568",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
         "mime": "^2.0.3",
@@ -14905,12 +17207,6 @@
           "requires": {
             "find-up": "^4.0.0"
           }
-        },
-        "ws": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
-          "dev": true
         }
       }
     },
@@ -14943,11 +17239,26 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
+    "queue-microtask": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
+      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA==",
+      "dev": true
+    },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "range-parser": {
       "version": "1.2.1",
@@ -14988,6 +17299,117 @@
         }
       }
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        }
+      }
+    },
+    "rdf-data-factory": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.0.0.tgz",
+      "integrity": "sha512-C+UBVeXchaywznF8VnmkRSanUpB3/f2iBrdqw2aPFqKlUgcRGHhAIQZ/AjfbM7u1beyNlEq2us3kvVIum6+uBg==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "*"
+      }
+    },
+    "rdf-literal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.1.1.tgz",
+      "integrity": "sha512-zYelIUgvwifeq2aFfTYlv+SoxZbSjdKw+I4ulZ5ECil8FTh2+ufHiR9P7T61KnVyo8BqBhyeHBR4UvA++PWozA==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^3.0.0"
+      }
+    },
+    "rdf-quad": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.4.0.tgz",
+      "integrity": "sha512-xChDvhK2zb4/aCg8P668CWTn4TEhscefg/E1s+Qu61sZ/hKct/WQn0wuHim8H+MFrzZ7fFN7Gh7aamPgm/QSwA==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "rdf-literal": "^1.0.0",
+        "rdf-string": "^1.3.1"
+      }
+    },
+    "rdf-store-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-1.0.1.tgz",
+      "integrity": "sha512-/aMMY3UeC1ONxnDoPgpeaZPT7coqeYRFQ1U30nuJ66f6OMDBag/iYtgu871hqobgKDZEmxg9Ut3USsZzvEry0Q==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^3.0.2",
+        "n3": "^1.1.1"
+      }
+    },
+    "rdf-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.5.0.tgz",
+      "integrity": "sha512-3TEJuDIKUADgZrfcZG+zAN4GfVA1Ei2sKA7Z7QVHkAE36wWoRGPJbGihPQMldgzvy9lG2nzZU+CXz+6oGSQNsQ==",
+      "dev": true,
+      "requires": {
+        "rdf-data-factory": "^1.0.0"
+      }
+    },
+    "rdf-string-ttl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-1.0.1.tgz",
+      "integrity": "sha512-QdOztnXuQTS5HwS2YTUkY9KUdyjyMYCX4QITfAAAtJnGqQkfah1L+VdV3E+Z3NKp/CBXLqZs/oMZe5J7pUEzpw==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1"
+      }
+    },
+    "rdf-terms": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.5.1.tgz",
+      "integrity": "sha512-dDhpUYxTAOWKT3Ln93A5k5UB5SftG8bPAzeZEjGeP4e7eboMhITUTDks8HDmUt9X1P+HpfnY/o6VSTSpf3Advw==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "lodash.uniqwith": "^4.5.0"
+      }
+    },
+    "rdfa-streaming-parser": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-1.2.2.tgz",
+      "integrity": "sha512-OKNyZworn+wuHd9DsskyiBor85nQPAMzSR/xm6np1Pe09edj3yRGJQLsY62Ww1ELjZbdEFXougIShhR9VwU83A==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^3.0.0",
+        "htmlparser2": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "rdfxml-streaming-parser": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.3.6.tgz",
+      "integrity": "sha512-t9uqmCiPjmMFMXQ3Va2rc4ePElhze63EUmXVLA05s40NQEvphj8I8Kl1qODBwHnxocdoc1yVQRsC6hVJAPHvPQ==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.2",
+        "relative-to-absolute-iri": "^1.0.0",
+        "sax": "^1.2.4"
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -15022,6 +17444,21 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "readable-stream-node-to-web": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
+      "integrity": "sha1-i3YU+qFGXr+g2pucpjA/onBzt88=",
+      "dev": true
+    },
+    "readdir-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.0.0.tgz",
+      "integrity": "sha512-km0DIcwQVZ1ZUhXhMWpF74/Wm5aFEd5/jDiVWF1Hkw2myPQovG8vCQ8+FQO2KXE9npQQvCnAMZhhWuUee4WcCQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
       }
     },
     "readdirp": {
@@ -15065,9 +17502,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
       "dev": true
     },
     "regenerator-transform": {
@@ -15136,6 +17573,12 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
+    "relative-to-absolute-iri": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.6.tgz",
+      "integrity": "sha512-Xw5/Zx6iWSCMJUXwXVOjySjH8Xli4hVFL9QQFvkl1qEmFBG94J+QUI9emnoctOCD3285f1jNV+QWV9eDYwIdfQ==",
       "dev": true
     },
     "remark-parse": {
@@ -15236,6 +17679,28 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "requireg": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/requireg/-/requireg-0.1.8.tgz",
+      "integrity": "sha512-qjbwnviLXg4oZiAFEr1ExbevkUPaEiP1uPGSoFCVgCCcbo4PXv9SmiJpXNYmgTBCZ8fY1Jy+sk7F9/kPNepeDw==",
+      "dev": true,
+      "requires": {
+        "nested-error-stacks": "~2.0.1",
+        "rc": "~1.2.7",
+        "resolve": "~1.7.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        }
+      }
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -15262,6 +17727,16 @@
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
       "integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==",
       "dev": true
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -15330,9 +17805,9 @@
       }
     },
     "resq": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resq/-/resq-1.7.1.tgz",
-      "integrity": "sha512-09u9Q5SAuJfAW5UoVAmvRtLvCOMaKP+djiixTXsZvPaojGKhuvc0Nfvp84U1rIfopJWEOXi5ywpCFwCk7mj8Xw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/resq/-/resq-1.8.0.tgz",
+      "integrity": "sha512-VObcnfPcE6/EKfHqsi5qoJ0+BF9qfl5181CytP1su3HgzilqF03DrQ+Y7kZQrd+5myfmantl9W3/5uUcpwvKeg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1"
@@ -15395,6 +17870,16 @@
         "glob": "^7.1.3"
       }
     },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "roarr": {
       "version": "2.15.3",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.3.tgz",
@@ -15418,22 +17903,22 @@
       }
     },
     "rollup": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.21.0.tgz",
-      "integrity": "sha512-BEGgy+wSzux7Ycq58pRiWEOBZaXRXTuvzl1gsm7gqmsAHxkWf9nyA5V2LN9fGSHhhDQd0/C13iRzSh4bbIpWZQ==",
+      "version": "2.26.7",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.7.tgz",
+      "integrity": "sha512-3/aXJ+ibw2fqj6KBX4ioYcx8s3kseYXzyxLR6Xmm7Zakzd7WNvn9XDUahBCQ/oPVHmVO9gEeIYKHgFaZWqsJzg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
       }
     },
     "rollup-plugin-babel": {
-      "version": "5.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-5.0.0-alpha.2.tgz",
-      "integrity": "sha512-G/QVa6yq7ieUr5jh4KENvpwcUwHiHk2PZqGOxsX4qBdXdk+F+wUQuKfE1XCpK5y0D9kaUPRrCC1P4Dj6MBIU6g==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
+      "integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.7.4",
-        "rollup-pluginutils": "^2.8.2"
+        "@babel/helper-module-imports": "^7.0.0",
+        "rollup-pluginutils": "^2.8.1"
       }
     },
     "rollup-plugin-cpy": {
@@ -15471,9 +17956,9 @@
       }
     },
     "rollup-plugin-postcss": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-3.1.3.tgz",
-      "integrity": "sha512-5Zm70/HkuYaQuhFbiGSO3U0bVj0magAPo09sd4sRE7I434Iwe4p7xF43pYfW0BcDvY0ZxzD3Fh2vRJzsm4OEiQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-3.1.6.tgz",
+      "integrity": "sha512-lkKMTXhPyaNgELFFf7mAGLqFTr13Lswak1YkP+b9rfl6YNVHxs3PYgZFAGLOyLvOtSuCVRq6BryXs1EgyC+nHQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -15540,9 +18025,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -15564,13 +18049,89 @@
       }
     },
     "rollup-plugin-workbox": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-workbox/-/rollup-plugin-workbox-5.0.1.tgz",
-      "integrity": "sha512-n8Zn+CRZZCnS3BG7l1nCMqo5vuEP5SZWUukreQlkoYm/i+gE1aZdr2bhif564CfbZHZBOPrJRA4BEOnxevqnRg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-workbox/-/rollup-plugin-workbox-5.2.1.tgz",
+      "integrity": "sha512-C+yIoYkZ3VUcJTZpOH2zbaarHCwy8eQod987eS8hXE6qwfMLDqV3RkLYNplnO0PcMi+3JgZPiE6d1zuXgwkO7Q==",
       "dev": true,
       "requires": {
+        "@rollup/plugin-node-resolve": "^8.4.0",
+        "@rollup/plugin-replace": "^2.3.3",
         "pretty-bytes": "^5.3.0",
+        "rollup-plugin-terser": "^6.1.0",
         "workbox-build": "^5.0.0"
+      },
+      "dependencies": {
+        "@rollup/plugin-node-resolve": {
+          "version": "8.4.0",
+          "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.4.0.tgz",
+          "integrity": "sha512-LFqKdRLn0ShtQyf6SBYO69bGE1upV6wUhBX0vFOUnLAyzx5cwp8svA0eHUnu8+YU57XOkrMtfG63QOpQx25pHQ==",
+          "dev": true,
+          "requires": {
+            "@rollup/pluginutils": "^3.1.0",
+            "@types/resolve": "1.17.1",
+            "builtin-modules": "^3.1.0",
+            "deep-freeze": "^0.0.1",
+            "deepmerge": "^4.2.2",
+            "is-module": "^1.0.0",
+            "resolve": "^1.17.0"
+          }
+        },
+        "@types/resolve": {
+          "version": "1.17.1",
+          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+          "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-worker": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+          "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "rollup-plugin-terser": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-6.1.0.tgz",
+          "integrity": "sha512-4fB3M9nuoWxrwm39habpd4hvrbrde2W2GG4zEGPQg1YITNkM3Tqur5jSuXlWNzbv/2aMLJ+dZJaySc3GCD8oDw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "jest-worker": "^26.0.0",
+            "serialize-javascript": "^3.0.0",
+            "terser": "^4.7.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+          "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "rollup-pluginutils": {
@@ -15597,9 +18158,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
-      "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
+      "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -15612,9 +18173,9 @@
       "dev": true
     },
     "safe-identifier": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.1.tgz",
-      "integrity": "sha512-73tOz5TXsq3apuCc3vC8c9QRhhdNZGiBhHmPPjqpH4TO5oCDqk8UIsDcSs/RG6dYcFAkOOva0pqHS3u7hh7XXA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
+      "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
       "dev": true
     },
     "safe-regex": {
@@ -15633,9 +18194,9 @@
       "dev": true
     },
     "saucelabs": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.4.3.tgz",
-      "integrity": "sha512-CA+p+P4a8yNIXerJ2HPFNkkmkblENL5CKWjjk0OqNfHVDAxfDoq6CJKeJByBTNOu90OtqA2sWAji9PsH/XoBEg==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.4.4.tgz",
+      "integrity": "sha512-RKem5TFBuGrQqUF4uhhVON+zXJSz8jOAzK4PTdwNRtgV30CayyvOOQnp2eC0KOnICnOEQgieaV9NUM6UH1PhuQ==",
       "dev": true,
       "requires": {
         "bin-wrapper": "^4.1.0",
@@ -15647,58 +18208,6 @@
         "yargs": "^15.3.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
         "form-data": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
@@ -15709,94 +18218,6 @@
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "dev": true,
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
         }
       }
     },
@@ -15806,24 +18227,40 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
-    "seek-bzip": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+    "sax-stream": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax-stream/-/sax-stream-1.3.0.tgz",
+      "integrity": "sha512-tcfsAAICAkyNNe4uiKtKmLKxx3C7qPAej13UUoN+7OLYq/P5kHGahZtJhhMVM3fIMndA6TlYHWFlFEzFkv1VGg==",
       "dev": true,
       "requires": {
-        "commander": "~2.8.1"
+        "debug": "~2",
+        "sax": "~1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
+      }
+    },
+    "seek-bzip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+      "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.8.1"
       }
     },
     "select": {
@@ -16040,6 +18477,16 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "dev": true
     },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "shady-css-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
@@ -16091,17 +18538,17 @@
       }
     },
     "sinon": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
-      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.2",
         "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/formatio": "^5.0.1",
-        "@sinonjs/samsam": "^5.0.3",
+        "@sinonjs/samsam": "^5.1.0",
         "diff": "^4.0.2",
-        "nise": "^4.0.1",
+        "nise": "^4.0.4",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
@@ -16118,9 +18565,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -16301,34 +18748,17 @@
       }
     },
     "socket.io": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
-      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.3.0.tgz",
+      "integrity": "sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==",
       "dev": true,
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
+        "debug": "~4.1.0",
+        "engine.io": "~3.4.0",
         "has-binary2": "~1.0.2",
         "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.1.1",
-        "socket.io-parser": "~3.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
+        "socket.io-client": "2.3.0",
+        "socket.io-parser": "~3.4.0"
       }
     },
     "socket.io-adapter": {
@@ -16338,64 +18768,27 @@
       "dev": true
     },
     "socket.io-client": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
+      "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
       "dev": true,
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.2.0",
+        "debug": "~4.1.0",
+        "engine.io-client": "~3.4.0",
         "has-binary2": "~1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.2.0",
+        "socket.io-parser": "~3.3.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-      "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
-      "dev": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
@@ -16406,6 +18799,47 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "socket.io-parser": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+          "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "debug": "~3.1.0",
+            "isarray": "2.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
+      "integrity": "sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "~4.1.0",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         }
       }
@@ -16476,6 +18910,97 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
+    },
+    "sparqlalgebrajs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.3.2.tgz",
+      "integrity": "sha512-QnjSz25c6ruALbxxD7e9E64hoi/yPMz5MzxUIjLEiTob2zWoM4Pj6GlYZAMnxcCdXXURZO+n0Obt/8XhQj4XiQ==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.2",
+        "fast-deep-equal": "^3.1.1",
+        "minimist": "^1.2.5",
+        "rdf-string": "^1.3.1",
+        "sparqljs": "^3.1.1"
+      }
+    },
+    "sparqlee": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.4.3.tgz",
+      "integrity": "sha512-HVWj816xZqUO14/kkA9I/OS+uF8zHe7MGCmoGb4gPcO2KcenF8hg4SssftcQgxVJzsI4RQV91rXhDYdBb1WF9g==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.0",
+        "@types/create-hash": "^1.2.0",
+        "@types/rdf-js": "^3.0.0",
+        "@types/uuid": "^8.0.0",
+        "create-hash": "^1.2.0",
+        "decimal.js": "^10.2.0",
+        "immutable": "^3.8.2",
+        "rdf-string": "^1.1.1",
+        "sparqlalgebrajs": "^2.1.0",
+        "uri-js": "^4.2.2",
+        "uuid": "^8.0.0"
+      }
+    },
+    "sparqljs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.1.1.tgz",
+      "integrity": "sha512-HYSwEu++souL4YjJbRx+3dJ1aNYNuR+BbZdPmdrmD4QMSO14J63BEshpcSURcNRsuriOI+05wo2AaxVvpjhgkg==",
+      "dev": true,
+      "requires": {
+        "n3": "^1.6.0"
+      }
+    },
+    "sparqljson-parse": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.5.2.tgz",
+      "integrity": "sha512-VnYzLsiha3Byb7iKr4qbwsztF7cjZFDEnJg2Z2fSbVlUOa4Pwk4cHem6SnFDBWRrOtu/N98v9/JMVRi6bQYqew==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/node": "^13.1.0",
+        "@types/rdf-js": "^3.0.0",
+        "JSONStream": "^1.3.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
+          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+          "dev": true
+        }
+      }
+    },
+    "sparqljson-to-tree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-2.0.0.tgz",
+      "integrity": "sha512-+2R6RtLYm5A3zA/SzIU/6RCp8lM2KQfJpos53BmkgRnHHHvP/ZVtMMnqY9IsV3msMLSCa/D/rS51ND8nCPwRoQ==",
+      "dev": true,
+      "requires": {
+        "rdf-literal": "^1.0.0",
+        "sparqljson-parse": "^1.5.0"
+      }
+    },
+    "sparqlxml-parse": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.3.0.tgz",
+      "integrity": "sha512-NeI5t7Jglue/CIl1LXAAXzK4k9Ex4ULuPpTShuEpID+edPmljJ17ITsgx1yM8exZR1a4br5UqyyiDxduQQ4wAw==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/node": "^13.1.0",
+        "@types/rdf-js": "^3.0.0",
+        "sax-stream": "^1.2.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
+          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+          "dev": true
+        }
+      }
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -16599,6 +19124,21 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
+    },
+    "stream-to-string": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.0.tgz",
+      "integrity": "sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==",
+      "dev": true,
+      "requires": {
+        "promise-polyfill": "^1.1.6"
+      }
+    },
+    "streamify-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/streamify-string/-/streamify-string-1.0.1.tgz",
+      "integrity": "sha1-niIN4z4cR13TDgIG9bGBXMbJUls=",
       "dev": true
     },
     "streamroller": {
@@ -16894,9 +19434,9 @@
       }
     },
     "systemjs": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.3.3.tgz",
-      "integrity": "sha512-djQ6mZ4/cWKnVnhAWvr/4+5r7QHnC7WiA8sS9VuYRdEv3wYZYTIIQv8zPT79PdDSUwfX3bgvu5mZ8eTyLm2YQA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.5.0.tgz",
+      "integrity": "sha512-B+NzKJD1srC/URfNVBdDExAUAsAVXpVQxZxX54AtqU0xiK9imkqurQu3qi6JdyA2GBAw2ssjolYIa7kh+xY1uw==",
       "dev": true
     },
     "table": {
@@ -16990,9 +19530,9 @@
       },
       "dependencies": {
         "bl": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-          "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
           "dev": true,
           "requires": {
             "buffer": "^5.5.0",
@@ -17533,9 +20073,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.2.tgz",
+      "integrity": "sha512-GXCYNwqoo0MbLARghYjxVBxDCnU0tLqN7IPLdHHbibCb1NI5zBkU2EPcy/GaVxc0BtTjqyGXJCINe6JMR2Dpow==",
       "dev": true
     },
     "ultron": {
@@ -17797,6 +20337,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "uritemplate": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/uritemplate/-/uritemplate-0.3.4.tgz",
+      "integrity": "sha1-BdCoU/+8iw9Jqj1NKtd3sNHuBww=",
+      "dev": true
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -17886,9 +20432,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-      "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
       "dev": true
     },
     "v8-compile-cache": {
@@ -18030,35 +20576,60 @@
       "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==",
       "dev": true
     },
+    "web-streams-node": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/web-streams-node/-/web-streams-node-0.4.0.tgz",
+      "integrity": "sha512-u+PBQs8DFaBrN/bxCLFn21tO/ZP7EM3qA4FGzppoUCcZ5CaMbKOsN8uOp27ylVEsfrxcR2tsF6gWHI5M8bN73w==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.1.0",
+        "readable-stream-node-to-web": "^1.0.1",
+        "web-streams-ponyfill": "^1.4.1"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        }
+      }
+    },
+    "web-streams-ponyfill": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz",
+      "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==",
+      "dev": true
+    },
     "webdriver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.3.0.tgz",
-      "integrity": "sha512-osHp5DX8eQ76Sy6/UYoECmDnUXwLhy5tlBeJh86er7S04FLAlmEqCvYXgxTSb8YtDjh9Xt9gP768RGhxR7ik5A==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.4.2.tgz",
+      "integrity": "sha512-8aj6zSxI9B9/O9DKiBUNc0BcmtEWHFcgeoVn0IqytTWN+M30UVrl1PuWPqrp2wTWMlW4ZAOW1ifnPQOBxbbniQ==",
       "dev": true,
       "requires": {
         "@wdio/config": "6.1.14",
         "@wdio/logger": "6.0.16",
-        "@wdio/protocols": "6.3.0",
-        "@wdio/utils": "6.3.0",
+        "@wdio/protocols": "6.3.6",
+        "@wdio/utils": "6.4.0",
         "got": "^11.0.2",
         "lodash.merge": "^4.6.1"
       }
     },
     "webdriverio": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.3.3.tgz",
-      "integrity": "sha512-/ahCs6sna4M+/GZ5RPh5LLTEzfh5+gJD0vOpmA4nmarpKjqnfuwtqTETjmQCfqKTjiLVwzqShnsAedbYuw9Q2g==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.4.4.tgz",
+      "integrity": "sha512-KmioPyB9JysQN+4Gwe3LRK5CLFwZp6T4S+oI8aFMUVUBbp7zJuosq8oLI1wJzTaysInotNldOCOC3dEIVjNyuQ==",
       "dev": true,
       "requires": {
         "@types/puppeteer": "^3.0.1",
         "@wdio/config": "6.1.14",
         "@wdio/logger": "6.0.16",
-        "@wdio/repl": "6.3.0",
-        "@wdio/utils": "6.3.0",
-        "archiver": "^4.0.1",
+        "@wdio/repl": "6.4.0",
+        "@wdio/utils": "6.4.0",
+        "archiver": "^5.0.0",
         "atob": "^2.1.2",
         "css-value": "^0.0.1",
-        "devtools": "6.3.3",
+        "devtools": "6.4.4",
         "get-port": "^5.1.1",
         "grapheme-splitter": "^1.0.2",
         "lodash.clonedeep": "^4.5.0",
@@ -18070,7 +20641,7 @@
         "resq": "^1.6.0",
         "rgb2hex": "^0.2.0",
         "serialize-error": "^7.0.0",
-        "webdriver": "6.3.0"
+        "webdriver": "6.4.2"
       }
     },
     "webidl-conversions": {
@@ -18080,9 +20651,9 @@
       "dev": true
     },
     "whatwg-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
-      "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
+      "integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==",
       "dev": true
     },
     "whatwg-url": {
@@ -18273,16 +20844,6 @@
             "acorn": "^7.1.0"
           }
         },
-        "rollup-plugin-babel": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
-          "integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "rollup-pluginutils": "^2.8.1"
-          }
-        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
@@ -18399,61 +20960,48 @@
       }
     },
     "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "color-name": "~1.1.4"
           }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -18474,20 +21022,27 @@
       }
     },
     "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
-      }
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+      "dev": true
     },
     "x-is-string": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw=",
       "dev": true
     },
     "xmlhttprequest-ssl": {
@@ -18521,21 +21076,102 @@
       "dev": true
     },
     "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
+        "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
+        "yargs-parser": "^18.1.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -18543,6 +21179,32 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
         },
         "emoji-regex": {
           "version": "7.0.3",
@@ -18618,36 +21280,46 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
-      }
-    },
-    "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        }
-      }
-    },
-    "yargs-unparser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
-      "dev": true,
-      "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
       }
     },
     "yauzl": {
@@ -18673,13 +21345,13 @@
       "dev": true
     },
     "zip-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-3.0.1.tgz",
-      "integrity": "sha512-r+JdDipt93ttDjsOVPU5zaq5bAyY+3H19bDrThkvuVxC0xMQzU1PJcS6D+KrP3u96gH9XLomcHPb+2skoDjulQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.2.tgz",
+      "integrity": "sha512-TGxB2g+1ur6MHkvM644DuZr8Uzyz0k0OYWtS3YlpfWBEmK4woaC2t3+pozEL3dBfIPmpgmClR5B2QRcMgGt22g==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
-        "compress-commons": "^3.0.0",
+        "compress-commons": "^4.0.0",
         "readable-stream": "^3.6.0"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@api-components/api-type-document": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-type-document/-/api-type-document-4.2.0.tgz",
-      "integrity": "sha512-mdR6SqXODcyHNPyYacYUlJIaC7CyV90CQmb4IhHOHzNKgiEVT5lVt+u5bEN7TkPIlypsSX4hcoUjwEEKeD3IaQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@api-components/api-type-document/-/api-type-document-4.2.1.tgz",
+      "integrity": "sha512-Gcdg2+0QuA2qHhc0f23z8qOb002QltpJOnHUsdW7L9GYGz5CW7mfbsCKcBysKPu4rrPPpJ9RbLf1lvp1EG4OCg==",
       "requires": {
         "@advanced-rest-client/arc-marked": "^1.0.6",
         "@advanced-rest-client/markdown-styles": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-console",
   "description": "The API Console to automatically generate API documentation from RAML and OAS files.",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "license": "CPAL-1.0",
   "main": "index.js",
   "module": "index.js",


### PR DESCRIPTION
Version 6.2.5 of the API Console includes fixes and features

### Fixes
- Changing RAML baseUri made query parameters section disappear
- Duplicated examples in type documentation
- Query string documentation was missing
- Media types selector was missing when multiple media types defined in spec
- Increase space between input and selectors and their labels
- Table view was not displaying string examples
- When setting no-auto-encoding annotation to URL elements, components were still being encoded

### Features
- New css variable for text wrapping for navigation items