### PR TITLE
Relase API Console 6.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api-console",
-  "version": "6.2.5",
+  "version": "6.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18,14 +18,12 @@
       }
     },
     "@advanced-rest-client/arc-icons": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-icons/-/arc-icons-3.1.0.tgz",
-      "integrity": "sha512-tM0lxKLcFvalWjIEG7lNbtrOe94SDq7EEgdZi24Oh3DScbX0YgCM7FH1gI51P9mP6iCas4x0cQF6wjmW7lFZ2Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-icons/-/arc-icons-3.1.2.tgz",
+      "integrity": "sha512-tcEc7vIzgSPu3uWycvxXcrecl5aoXzXQPbpDGKEhL7k6rFH3h6QmPwNC+AQmYpBhJcVKRVuY42zcX+uXb92GYQ==",
       "requires": {
-        "@polymer/iron-icon": "^3.0.1",
-        "@polymer/iron-iconset-svg": "^3.0.1",
-        "lit-element": "^2.2.1",
-        "lit-html": "^1.1.2"
+        "lit-element": "^2.4.0",
+        "lit-html": "^1.3.0"
       }
     },
     "@advanced-rest-client/arc-marked": {
@@ -205,15 +203,15 @@
       }
     },
     "@advanced-rest-client/http-code-snippets": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/http-code-snippets/-/http-code-snippets-3.1.2.tgz",
-      "integrity": "sha512-pT8ftoBLkPrQKMF32wL6fQ386pcAjRpw48CgxuMAA/zzxMgdCG45ovNA4fGvq4va8LPu2OQJKfX17sPkvW8esA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/http-code-snippets/-/http-code-snippets-3.2.0.tgz",
+      "integrity": "sha512-HRenBCl6u18tO8EGxGuMJtE/gw0OgvvqhRdtkf4t6J69iytVzcPt0ljGTyZGTAE/uWImfjAGnPqtwiA173jFIQ==",
       "requires": {
-        "@anypoint-web-components/anypoint-button": "^1.0.15",
-        "@anypoint-web-components/anypoint-tabs": "^0.1.10",
+        "@anypoint-web-components/anypoint-button": "^1.1.1",
+        "@anypoint-web-components/anypoint-tabs": "^0.1.11",
         "@polymer/prism-element": "^3.0.0",
-        "lit-element": "^2.2.1",
-        "prismjs": "^1.19.0"
+        "lit-element": "^2.4.0",
+        "prismjs": "^1.21.0"
       }
     },
     "@advanced-rest-client/http-method-selector": {
@@ -449,27 +447,27 @@
       }
     },
     "@advanced-rest-client/testing-karma-sl": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/testing-karma-sl/-/testing-karma-sl-1.4.1.tgz",
-      "integrity": "sha512-iba/zY3KO6YcJbPkdkO/5F6Rx5T2R3zJuOvF55KDU/QH6RS5EEI2OTU/LbwzjyiV8ty/K7NMqj4LA1wnO0z1cw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/testing-karma-sl/-/testing-karma-sl-1.4.2.tgz",
+      "integrity": "sha512-lC3vslh04+rFkuYZvmXlF0pQUwQcGwrXYuo/lhbp7B1LA/UNW1J/JcSH3uo/RwDWp8oK6AYPoEhcTVzFB4Qg/w==",
       "dev": true,
       "requires": {
-        "@open-wc/testing-karma": "^4.0.3",
+        "@open-wc/testing-karma": "^4.0.5",
         "karma-sauce-launcher": "^4.1.5"
       },
       "dependencies": {
         "@open-wc/testing-karma": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-4.0.5.tgz",
-          "integrity": "sha512-yEllAsQkw25dorjKJ8Ry4IXi1qHqDPxEU8GdycGs5FQYtKPUQZtzMGooE/lVzmeJpvU0tT9DcAjgAU2Yob1lxA==",
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-4.0.6.tgz",
+          "integrity": "sha512-IFzF74IUnJ8GjQovHqIUV0wK7IucQmsBjiTUrAquuSyRdxAzz6AKpWSfYduUQyBpEZ+yWc3+rnispnXgpz/4gA==",
           "dev": true,
           "requires": {
-            "@open-wc/karma-esm": "^3.0.5",
+            "@open-wc/karma-esm": "^3.0.6",
             "@types/karma": "^5.0.0",
             "@types/karma-coverage-istanbul-reporter": "^2.1.0",
             "@types/karma-mocha": "^1.3.0",
             "@types/karma-mocha-reporter": "^2.2.0",
-            "axe-core": "^3.5.3",
+            "axe-core": "^4.0.2",
             "karma": "^5.1.1",
             "karma-chrome-launcher": "^3.1.0",
             "karma-coverage": "^2.0.2",
@@ -504,16 +502,16 @@
       }
     },
     "@anypoint-web-components/anypoint-autocomplete": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-autocomplete/-/anypoint-autocomplete-0.2.2.tgz",
-      "integrity": "sha512-8OhCS848jfDY1wZ9zliqeCAFCYhEAJOnvyjV078X+FdnwYL3MzHLIdBbfI14zBBFoLHvXstANf0v8mZdI3IpLA==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-autocomplete/-/anypoint-autocomplete-0.2.6.tgz",
+      "integrity": "sha512-Mte1sjGVF19Qra+dPvxTLLKeFuGNTg3166Ozi9bPfZ7jAmC8PX6macBvdFJscr9heM4myxgnfdEe127+2LOepQ==",
       "requires": {
         "@anypoint-web-components/anypoint-dropdown": "^1.1.2",
-        "@anypoint-web-components/anypoint-item": "^1.0.7",
+        "@anypoint-web-components/anypoint-item": "^1.0.8",
         "@anypoint-web-components/anypoint-listbox": "^1.1.4",
         "@polymer/paper-progress": "^3.0.0",
         "@polymer/paper-ripple": "^3.0.2",
-        "lit-element": "^2.3.1"
+        "lit-element": "^2.4.0"
       }
     },
     "@anypoint-web-components/anypoint-button": {
@@ -537,11 +535,11 @@
       }
     },
     "@anypoint-web-components/anypoint-control-mixins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-control-mixins/-/anypoint-control-mixins-1.1.1.tgz",
-      "integrity": "sha512-s1VX8EQnogzo5aLjoyxnLuLVzEoZ0rL6LMlV3gEM1g1SJbZyy7SFLMrbiiQheq1zyJMUUEcoux5Jpkadb7R1dg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-control-mixins/-/anypoint-control-mixins-1.1.2.tgz",
+      "integrity": "sha512-zlVljIGLDbSGUDdz78U4ouwpQu5j4OdFjqZ5wAtnRG2jXb6XZu0bJ3lC9ubCnm2BDIJS6lQWKa9Bc1yknMJJOQ==",
       "requires": {
-        "@open-wc/dedupe-mixin": "^1.2.17"
+        "@open-wc/dedupe-mixin": "^1.3.0"
       }
     },
     "@anypoint-web-components/anypoint-dropdown": {
@@ -569,37 +567,37 @@
       }
     },
     "@anypoint-web-components/anypoint-form-mixins": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-form-mixins/-/anypoint-form-mixins-1.2.0.tgz",
-      "integrity": "sha512-oVnRSy80vbYCGWWsRDl6T82Dp/Z2kAHzsc1GeW/7tg3mC+KcXXrW7+RuAfzmKk90Bd/WcVb/NCOt9YHOSluUpA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-form-mixins/-/anypoint-form-mixins-1.2.1.tgz",
+      "integrity": "sha512-xPCIQjozIndY//eqAF6dMFV9ILiPKu8+GZQBBxGFE7udcpq7N6aGAF0gtR+A4OtfcIJMoZVtaw0XZtuQGWXZSQ==",
       "requires": {
-        "@anypoint-web-components/validatable-mixin": "^1.1.1",
-        "@open-wc/dedupe-mixin": "^1.2.17"
+        "@anypoint-web-components/validatable-mixin": "^1.1.3",
+        "@open-wc/dedupe-mixin": "^1.3.0"
       }
     },
     "@anypoint-web-components/anypoint-input": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-input/-/anypoint-input-0.2.20.tgz",
-      "integrity": "sha512-sexH3RU+fkzf3MLJKgwzB3RRjzVkO3l1tA/V8yvLlPIlDXmp0oESkpXZEmVsq8aQ0p6AGlRJjgmkqlhr1UJbog==",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-input/-/anypoint-input-0.2.21.tgz",
+      "integrity": "sha512-NRRvFe9lfOJ8eBQgKRyt31zU0KSmQkc8bl4BqEtTB3YNOD+h6U3euDABgTHeVNw4Ogxjut2yqB/p4hPXVYa6FQ==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.1.0",
         "@anypoint-web-components/anypoint-button": "^1.1.1",
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.1",
-        "@anypoint-web-components/validatable-mixin": "^1.1.1",
-        "@open-wc/dedupe-mixin": "^1.2.18",
-        "lit-element": "^2.3.1",
-        "lit-html": "^1.2.1"
+        "@anypoint-web-components/anypoint-control-mixins": "^1.1.2",
+        "@anypoint-web-components/validatable-mixin": "^1.1.2",
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit-element": "^2.4.0",
+        "lit-html": "^1.3.0"
       }
     },
     "@anypoint-web-components/anypoint-item": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-item/-/anypoint-item-1.0.7.tgz",
-      "integrity": "sha512-5sGJCR50FGeu3LPKgurpzXpjgzHpWUQ/TECxoHARnKmUt1peItsBRVU8I5kjhQvqNVVenRD9I+W/78Jw80ElHw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-item/-/anypoint-item-1.0.8.tgz",
+      "integrity": "sha512-eqS74CXXIHHyU0Q9QbubfOqURQBLlZETRSJ/qs3AE47Hg6qO1Hr8DNy15qwECGsdm/rZ611K73ZJCuQtC0FRSA==",
       "requires": {
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.1",
+        "@anypoint-web-components/anypoint-control-mixins": "^1.1.2",
         "@anypoint-web-components/anypoint-styles": "^1.0.1",
-        "lit-element": "^2.3.1",
-        "lit-html": "^1.2.1"
+        "lit-element": "^2.4.0",
+        "lit-html": "^1.3.0"
       }
     },
     "@anypoint-web-components/anypoint-listbox": {
@@ -613,35 +611,35 @@
       }
     },
     "@anypoint-web-components/anypoint-menu-mixin": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-menu-mixin/-/anypoint-menu-mixin-1.1.6.tgz",
-      "integrity": "sha512-VebfeZArRWwETAw8IZNnvoWW2++M+Xy5ePtj3vLibInETCUclM/io5q/ZfpTdHO1Z9utP1cexG+mSGOe9ilNcA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-menu-mixin/-/anypoint-menu-mixin-1.1.7.tgz",
+      "integrity": "sha512-yw4Cb3kU2TJSKGlkz1gvJG+vlZQ9NcCzwjSXabAWf8zV2bUIlNry97wYgof00t3Ql6VUW+wSnLVyKZxzrzN41Q==",
       "requires": {
-        "@anypoint-web-components/anypoint-selector": "^1.1.3",
-        "@open-wc/dedupe-mixin": "^1.2.17",
-        "lit-element": "^2.3.1",
-        "lit-html": "^1.2.1"
+        "@anypoint-web-components/anypoint-selector": "^1.1.5",
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit-element": "^2.4.0",
+        "lit-html": "^1.3.0"
       }
     },
     "@anypoint-web-components/anypoint-radio-button": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-radio-button/-/anypoint-radio-button-0.1.5.tgz",
-      "integrity": "sha512-Ajq6HtOrw7fiHf7Etl6YcP5Ft/N1eukIZX6mPFQSLg0JtTS3xpSmVREY+NcUJNZ+4ZZ8ojU9RsX17IQ0mYiB7g==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-radio-button/-/anypoint-radio-button-0.1.6.tgz",
+      "integrity": "sha512-WOT4jXDoa40tPxySjF39pidATUvnlBO7UmqTTNLzsCjxSUy9hETP2yxE7ok4Qe6tvI5vHfaTxcho535a5X0tTQ==",
       "requires": {
-        "@anypoint-web-components/anypoint-form-mixins": "^1.2.0",
-        "@anypoint-web-components/anypoint-menu-mixin": "^1.1.6",
+        "@anypoint-web-components/anypoint-form-mixins": "^1.2.1",
+        "@anypoint-web-components/anypoint-menu-mixin": "^1.1.7",
         "@anypoint-web-components/anypoint-styles": "^1.0.1",
-        "lit-element": "^2.3.1"
+        "lit-element": "^2.4.0"
       }
     },
     "@anypoint-web-components/anypoint-selector": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-selector/-/anypoint-selector-1.1.3.tgz",
-      "integrity": "sha512-yyg/w46SbKtTx7Ldnp6h+bMPXjPQAY27smHfR3VMQ3ir1O7o8l/yrY9Xgl185Fh/TXy4VOjwjmR6yccgkH5+5A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-selector/-/anypoint-selector-1.1.5.tgz",
+      "integrity": "sha512-gxTifvN5Xy42J4qIAFqfB3w0TnIa8obnIdt6BI46CErITVddRKyHVv9HmbNFZzdQEpDZ0LOq03EUTX0HW9nhKw==",
       "requires": {
-        "@open-wc/dedupe-mixin": "^1.2.17",
-        "lit-element": "^2.3.1",
-        "lit-html": "^1.2.1"
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit-element": "^2.4.0",
+        "lit-html": "^1.3.0"
       }
     },
     "@anypoint-web-components/anypoint-styles": {
@@ -679,12 +677,12 @@
       }
     },
     "@anypoint-web-components/validatable-mixin": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/validatable-mixin/-/validatable-mixin-1.1.1.tgz",
-      "integrity": "sha512-YGUWS+bi1SW5pG9irzPQGHDMr9MNStenRCUQnOmkCsp+RIi7eVkx3vP3uAUH4cI3/4/LcVTNSztnagryP+ZwGw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/validatable-mixin/-/validatable-mixin-1.1.3.tgz",
+      "integrity": "sha512-cObFmNCIWxbGoYEO7cMUEEB4LQ4n3HEgk1gS7LB/TZSvXzzth00f3lbxkvQsubBIFVEOKFUq5Lo8vuG81t0/2w==",
       "requires": {
         "@anypoint-web-components/validator-mixin": "^1.1.1",
-        "@open-wc/dedupe-mixin": "^1.2.17"
+        "@open-wc/dedupe-mixin": "^1.3.0"
       }
     },
     "@anypoint-web-components/validator-mixin": {
@@ -743,21 +741,21 @@
       }
     },
     "@api-components/api-body-document": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@api-components/api-body-document/-/api-body-document-4.1.2.tgz",
-      "integrity": "sha512-d6wpNTWp6xLPBeZ3d5ea8sqiy69AnMurDfV7/j6S61JvO/IPo+0DQhE7l1e6nqV2TbcNE8Nt3kBv8J+FvwjapQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@api-components/api-body-document/-/api-body-document-4.2.0.tgz",
+      "integrity": "sha512-ZUCj7/+CMhEHYdUVVdNuq41hXXAeVavLgWRHm6kjgwdiIcWhBP3koFSnd2/xULn4Rm9gSV6QIayGm1vZy4uDYg==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.0.4",
         "@advanced-rest-client/arc-marked": "^1.0.6",
         "@advanced-rest-client/markdown-styles": "^3.1.1",
         "@anypoint-web-components/anypoint-button": "^1.0.15",
-        "@api-components/amf-helper-mixin": "^4.1.6",
-        "@api-components/api-resource-example-document": "^4.1.0",
+        "@api-components/amf-helper-mixin": "^4.1.8",
+        "@api-components/api-resource-example-document": "^4.1.1",
         "@api-components/api-schema-document": "^4.0.3",
-        "@api-components/api-type-document": "^4.2.0",
+        "@api-components/api-type-document": "^4.2.2",
         "@api-components/raml-aware": "^3.0.0",
         "@polymer/iron-collapse": "^3.0.0",
-        "lit-element": "^2.2.1"
+        "lit-element": "^2.4.0"
       }
     },
     "@api-components/api-body-editor": {
@@ -794,9 +792,9 @@
       }
     },
     "@api-components/api-documentation": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@api-components/api-documentation/-/api-documentation-5.0.3.tgz",
-      "integrity": "sha512-2suT6ma1RUFZAgs0dVI3R9E4E7rYSlrxZOeGV/0jDdXlM4w7zzaXRS41vWYUQOPiXlZmHJElnaF5E84HiUIr8g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@api-components/api-documentation/-/api-documentation-5.0.4.tgz",
+      "integrity": "sha512-NghXAVteB/AmQzm9oUILVFQnvKNwN+zkUmvbKqzqSpV0P+PvHeLPCrAxdDJAz5C46REEHUKCvKCaNpeVD4ZzEw==",
       "requires": {
         "@advanced-rest-client/events-target-mixin": "^3.0.0",
         "@api-components/amf-helper-mixin": "^4.1.3",
@@ -848,12 +846,12 @@
       }
     },
     "@api-components/api-example-generator": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@api-components/api-example-generator/-/api-example-generator-4.4.2.tgz",
-      "integrity": "sha512-Y6LXdOV9jPbZVMoTueqmjsohlk7+xyQdiIIth0t/hKi/P8Kjl2c6Zv3AXAcsmX8Yvttgbf/MdDk/RL6wGmAanw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@api-components/api-example-generator/-/api-example-generator-4.4.5.tgz",
+      "integrity": "sha512-qwnpfmVrw0lNTicqyWvjY8iIl2qSb9z5NOJu2h4aNQD4Pkax9PcjTNCsLoWwWR/2oSy6djbI4iOgdcre5X5yuQ==",
       "requires": {
-        "@api-components/amf-helper-mixin": "^4.1.1",
-        "lit-element": "^2.3.1"
+        "@api-components/amf-helper-mixin": "^4.1.8",
+        "lit-element": "^2.4.0"
       }
     },
     "@api-components/api-form-mixin": {
@@ -1156,9 +1154,9 @@
       }
     },
     "@api-components/api-type-document": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@api-components/api-type-document/-/api-type-document-4.2.1.tgz",
-      "integrity": "sha512-Gcdg2+0QuA2qHhc0f23z8qOb002QltpJOnHUsdW7L9GYGz5CW7mfbsCKcBysKPu4rrPPpJ9RbLf1lvp1EG4OCg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@api-components/api-type-document/-/api-type-document-4.2.3.tgz",
+      "integrity": "sha512-vXGzblBoLU0eh9b2jO8U6XYgofZ+KZoYgMOuQMtGvF5krXwi9+xBK1D0CbPTzpJ4w+KILgqz8mipuGCHvwVHTA==",
       "requires": {
         "@advanced-rest-client/arc-marked": "^1.0.6",
         "@advanced-rest-client/markdown-styles": "^3.1.2",
@@ -1288,19 +1286,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.11.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.4.tgz",
-      "integrity": "sha512-5deljj5HlqRXN+5oJTY7Zs37iH3z3b++KjiKtIsJy1NrjOOVSEaJHEetLBhyu0aQOSNNZ/0IuEAan9GzRuDXHg==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.4",
+        "@babel/generator": "^7.11.6",
         "@babel/helper-module-transforms": "^7.11.0",
         "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.11.4",
+        "@babel/parser": "^7.11.5",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.11.0",
-        "@babel/types": "^7.11.0",
+        "@babel/traverse": "^7.11.5",
+        "@babel/types": "^7.11.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -1329,12 +1327,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.11.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
-      "integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.11.0",
+        "@babel/types": "^7.11.5",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -1625,9 +1623,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.11.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
-      "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -2129,9 +2127,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
-      "integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
+      "integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
@@ -2216,9 +2214,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-      "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",
+      "integrity": "sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.11.0",
@@ -2283,7 +2281,7 @@
         "@babel/plugin-transform-unicode-escapes": "^7.10.4",
         "@babel/plugin-transform-unicode-regex": "^7.10.4",
         "@babel/preset-modules": "^0.1.3",
-        "@babel/types": "^7.11.0",
+        "@babel/types": "^7.11.5",
         "browserslist": "^4.12.0",
         "core-js-compat": "^3.6.2",
         "invariant": "^2.2.2",
@@ -2333,26 +2331,26 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
-      "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+      "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.0",
+        "@babel/generator": "^7.11.5",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.11.0",
-        "@babel/types": "^7.11.0",
+        "@babel/parser": "^7.11.5",
+        "@babel/types": "^7.11.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       }
     },
     "@babel/types": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-      "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+      "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -2852,38 +2850,39 @@
       }
     },
     "@comunica/actor-abstract-bindings-hash": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.16.0.tgz",
-      "integrity": "sha512-W7oU8J0n6wC8R8EQ7UEvdmaJXf/Z3gEVCw9H+WXJSTEg1B77nrHuQs1lJreteKCIJEhC7BQYLtrfKE5N92edKw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.17.0.tgz",
+      "integrity": "sha512-NHeeANFD71fs2Pw+2hgYgNAhZXn3Krl0+x+0P+ciu4cslr1KDBM/N3ClVUaEok3HlQdG4lo9lw3EUhc0jZIUNg==",
       "dev": true,
       "requires": {
         "canonicalize": "^1.0.1",
-        "rdf-string": "^1.4.2"
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-abstract-mediatyped": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.15.0.tgz",
-      "integrity": "sha512-rB0DnIuiZKGqAd6JmcXdajmgDPWzffqCqLyAp2A967NRN1NlPbPnfwkCJBHVehdcyT69dAaEkHoHDZpbwOVjHg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.17.0.tgz",
+      "integrity": "sha512-IojYI3lYqOSf5aXHpVtiWh76+meuS730slmmyYB3AMi30vlxkUu8yQdrNQCywZBDmjBWeMueTLSRhRhpmHmTHg==",
       "dev": true
     },
     "@comunica/actor-abstract-path": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.16.0.tgz",
-      "integrity": "sha512-a53X/a9DTl6rYNbBGXCmUY9crusU6ySAiRZY3usiPWzqHeiZonM5+eRKzYm8vazxg3hLBs8jowKiZhiUPrx4wQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.17.0.tgz",
+      "integrity": "sha512-rjdnG0KCbjJjR1GboP1peEodu9i9lPoQ6knt8ijaUHAtionVa9UhXO+kTrDVq0yH/Vi6+Z314zXdMDjnl3e6FA==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "rdf-string": "^1.4.2",
-        "sparqlalgebrajs": "^2.3.2"
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-http-memento": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.16.0.tgz",
-      "integrity": "sha512-X58EUsxFch+/VoS58Ld1yFsSNjeu7xYtvPV6x4IpGv16V+QJot4KyKH25+SAwNOQDiRxShX55FovCCVvSxK35w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.17.0.tgz",
+      "integrity": "sha512-WWqfIrWf9ucC2k5SFA0CVecq6wpo6XgJ7lsDaQ28gWmrpRu23lVX99m2RjDCmldq1ksPh32nXteqAB8rj77Qig==",
       "dev": true,
       "requires": {
         "@types/parse-link-header": "^1.0.0",
@@ -2892,9 +2891,9 @@
       }
     },
     "@comunica/actor-http-native": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.16.2.tgz",
-      "integrity": "sha512-KhmYTKOmf4QZwd8CVy4f4o6d/LVzBy19JmpOIP1vLcOTAVOXg6KXDT+NEVSoDIc9T5fpKDh91bWuukptUqVjig==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.17.0.tgz",
+      "integrity": "sha512-XNjVeqkwMzYWCmBYVrcXYcGMkGH0oIP5KtKrPwn7N1+rTOQKvQg5+qf51g/5OepoEPBuvk0sFf2BfMXzY11j4w==",
       "dev": true,
       "requires": {
         "@types/parse-link-header": "^1.0.0",
@@ -2904,476 +2903,509 @@
       }
     },
     "@comunica/actor-http-proxy": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.16.0.tgz",
-      "integrity": "sha512-5aD5y9b6DvcCX2/ud/aVvUjvipppMmzKRV3C0evbA3NoAZ4VF8ejD+JpIjDsrvrbWeXVPueXvL/yfssUz17iIg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.17.0.tgz",
+      "integrity": "sha512-TValoWfkeUl5HNVq9416W/IjnW1YIcaaEZKz9ai7Oygy8AmhpqhM2lN265KdFgwT72/yNeCbtgTSGGHcqQuPCQ==",
       "dev": true
     },
     "@comunica/actor-init-sparql": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.16.2.tgz",
-      "integrity": "sha512-jzE/sW1ciNXtO/tRYEhSiKFxpB9/cqPME9a2jq/GYq9PmTv5MzcUbZEY7x8QRkRQ3Dp0Z2JHI/sorps8LPwcmQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.17.0.tgz",
+      "integrity": "sha512-DHHsoiHSvc4HrsF72SFLUAhhohy/li2O0ohjqRVpEs+8vzC6E9nlAM0mVSX41ZNqHDLPVawWDyBUb/58PyU9Ig==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.16.0",
-        "@comunica/actor-abstract-mediatyped": "^1.15.0",
-        "@comunica/actor-http-memento": "^1.16.0",
-        "@comunica/actor-http-native": "^1.16.2",
-        "@comunica/actor-http-proxy": "^1.16.0",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^1.16.0",
-        "@comunica/actor-query-operation-ask": "^1.16.0",
-        "@comunica/actor-query-operation-bgp-empty": "^1.16.0",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.16.0",
-        "@comunica/actor-query-operation-bgp-single": "^1.16.0",
-        "@comunica/actor-query-operation-construct": "^1.16.0",
-        "@comunica/actor-query-operation-describe-subject": "^1.16.0",
-        "@comunica/actor-query-operation-distinct-hash": "^1.16.0",
-        "@comunica/actor-query-operation-extend": "^1.16.0",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.16.0",
-        "@comunica/actor-query-operation-from-quad": "^1.16.0",
-        "@comunica/actor-query-operation-group": "^1.16.0",
-        "@comunica/actor-query-operation-join": "^1.16.0",
-        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.16.0",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.16.0",
-        "@comunica/actor-query-operation-minus": "^1.16.0",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.16.0",
-        "@comunica/actor-query-operation-path-alt": "^1.16.0",
-        "@comunica/actor-query-operation-path-inv": "^1.16.0",
-        "@comunica/actor-query-operation-path-link": "^1.16.0",
-        "@comunica/actor-query-operation-path-nps": "^1.16.0",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.16.0",
-        "@comunica/actor-query-operation-path-seq": "^1.16.0",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.16.0",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.16.0",
-        "@comunica/actor-query-operation-project": "^1.16.0",
-        "@comunica/actor-query-operation-quadpattern": "^1.16.0",
-        "@comunica/actor-query-operation-reduced-hash": "^1.16.0",
-        "@comunica/actor-query-operation-service": "^1.16.0",
-        "@comunica/actor-query-operation-slice": "^1.16.0",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.16.0",
-        "@comunica/actor-query-operation-union": "^1.16.0",
-        "@comunica/actor-query-operation-values": "^1.16.0",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.16.0",
-        "@comunica/actor-rdf-join-multi-smallest": "^1.16.0",
-        "@comunica/actor-rdf-join-nestedloop": "^1.16.0",
-        "@comunica/actor-rdf-join-symmetrichash": "^1.16.0",
-        "@comunica/actor-rdf-metadata-all": "^1.15.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.15.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.15.0",
-        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.15.0",
-        "@comunica/actor-rdf-metadata-primary-topic": "^1.15.0",
-        "@comunica/actor-rdf-parse-html": "^1.15.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "^1.15.0",
-        "@comunica/actor-rdf-parse-html-script": "^1.16.1",
-        "@comunica/actor-rdf-parse-jsonld": "^1.16.0",
-        "@comunica/actor-rdf-parse-n3": "^1.15.0",
-        "@comunica/actor-rdf-parse-rdfxml": "^1.15.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^1.15.0",
-        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.15.0",
-        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.15.0",
-        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.16.0",
-        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.16.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.16.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.16.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.16.0",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.15.0",
-        "@comunica/actor-rdf-serialize-n3": "^1.15.0",
-        "@comunica/actor-sparql-parse-algebra": "^1.16.0",
-        "@comunica/actor-sparql-parse-graphql": "^1.15.0",
-        "@comunica/actor-sparql-serialize-json": "^1.16.0",
-        "@comunica/actor-sparql-serialize-rdf": "^1.16.0",
-        "@comunica/actor-sparql-serialize-simple": "^1.16.0",
-        "@comunica/actor-sparql-serialize-sparql-csv": "^1.16.0",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.16.0",
-        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.16.0",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.16.0",
-        "@comunica/actor-sparql-serialize-stats": "^1.16.0",
-        "@comunica/actor-sparql-serialize-table": "^1.16.0",
-        "@comunica/actor-sparql-serialize-tree": "^1.16.0",
-        "@comunica/bus-context-preprocess": "^1.15.0",
-        "@comunica/bus-http": "^1.16.0",
-        "@comunica/bus-http-invalidate": "^1.15.0",
-        "@comunica/bus-init": "^1.15.0",
-        "@comunica/bus-optimize-query-operation": "^1.16.0",
-        "@comunica/bus-query-operation": "^1.16.0",
-        "@comunica/bus-rdf-dereference": "^1.15.0",
-        "@comunica/bus-rdf-dereference-paged": "^1.15.0",
-        "@comunica/bus-rdf-join": "^1.16.0",
-        "@comunica/bus-rdf-metadata": "^1.15.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.15.0",
-        "@comunica/bus-rdf-parse": "^1.15.0",
-        "@comunica/bus-rdf-parse-html": "^1.15.0",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.15.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.15.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.16.0",
-        "@comunica/bus-rdf-serialize": "^1.15.0",
-        "@comunica/bus-sparql-parse": "^1.15.0",
-        "@comunica/bus-sparql-serialize": "^1.16.0",
-        "@comunica/core": "^1.15.0",
-        "@comunica/logger-pretty": "^1.15.0",
-        "@comunica/logger-void": "^1.15.0",
-        "@comunica/mediator-all": "^1.15.0",
-        "@comunica/mediator-combine-pipeline": "^1.15.0",
-        "@comunica/mediator-combine-union": "^1.15.0",
-        "@comunica/mediator-number": "^1.15.0",
-        "@comunica/mediator-race": "^1.15.0",
-        "@comunica/runner": "^1.16.0",
-        "@comunica/runner-cli": "^1.16.0",
+        "@comunica/actor-abstract-bindings-hash": "^1.17.0",
+        "@comunica/actor-abstract-mediatyped": "^1.17.0",
+        "@comunica/actor-http-memento": "^1.17.0",
+        "@comunica/actor-http-native": "^1.17.0",
+        "@comunica/actor-http-proxy": "^1.17.0",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^1.17.0",
+        "@comunica/actor-query-operation-ask": "^1.17.0",
+        "@comunica/actor-query-operation-bgp-empty": "^1.17.0",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.17.0",
+        "@comunica/actor-query-operation-bgp-single": "^1.17.0",
+        "@comunica/actor-query-operation-construct": "^1.17.0",
+        "@comunica/actor-query-operation-describe-subject": "^1.17.0",
+        "@comunica/actor-query-operation-distinct-hash": "^1.17.0",
+        "@comunica/actor-query-operation-extend": "^1.17.0",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.17.0",
+        "@comunica/actor-query-operation-from-quad": "^1.17.0",
+        "@comunica/actor-query-operation-group": "^1.17.0",
+        "@comunica/actor-query-operation-join": "^1.17.0",
+        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.17.0",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.17.0",
+        "@comunica/actor-query-operation-minus": "^1.17.0",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.17.0",
+        "@comunica/actor-query-operation-path-alt": "^1.17.0",
+        "@comunica/actor-query-operation-path-inv": "^1.17.0",
+        "@comunica/actor-query-operation-path-link": "^1.17.0",
+        "@comunica/actor-query-operation-path-nps": "^1.17.0",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.17.0",
+        "@comunica/actor-query-operation-path-seq": "^1.17.0",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.17.0",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.17.0",
+        "@comunica/actor-query-operation-project": "^1.17.0",
+        "@comunica/actor-query-operation-quadpattern": "^1.17.0",
+        "@comunica/actor-query-operation-reduced-hash": "^1.17.0",
+        "@comunica/actor-query-operation-service": "^1.17.0",
+        "@comunica/actor-query-operation-slice": "^1.17.0",
+        "@comunica/actor-query-operation-sparql-endpoint": "^1.17.0",
+        "@comunica/actor-query-operation-union": "^1.17.0",
+        "@comunica/actor-query-operation-values": "^1.17.0",
+        "@comunica/actor-rdf-dereference-http-parse": "^1.17.0",
+        "@comunica/actor-rdf-join-multi-smallest": "^1.17.0",
+        "@comunica/actor-rdf-join-nestedloop": "^1.17.0",
+        "@comunica/actor-rdf-join-symmetrichash": "^1.17.0",
+        "@comunica/actor-rdf-metadata-all": "^1.17.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.17.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.17.0",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.17.0",
+        "@comunica/actor-rdf-metadata-primary-topic": "^1.17.0",
+        "@comunica/actor-rdf-parse-html": "^1.17.0",
+        "@comunica/actor-rdf-parse-html-rdfa": "^1.17.0",
+        "@comunica/actor-rdf-parse-html-script": "^1.17.0",
+        "@comunica/actor-rdf-parse-jsonld": "^1.17.0",
+        "@comunica/actor-rdf-parse-n3": "^1.17.0",
+        "@comunica/actor-rdf-parse-rdfxml": "^1.17.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^1.17.0",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.17.0",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.17.0",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.17.0",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.17.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.17.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.17.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.17.0",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.17.0",
+        "@comunica/actor-rdf-serialize-n3": "^1.17.0",
+        "@comunica/actor-sparql-parse-algebra": "^1.17.0",
+        "@comunica/actor-sparql-parse-graphql": "^1.17.0",
+        "@comunica/actor-sparql-serialize-json": "^1.17.0",
+        "@comunica/actor-sparql-serialize-rdf": "^1.17.0",
+        "@comunica/actor-sparql-serialize-simple": "^1.17.0",
+        "@comunica/actor-sparql-serialize-sparql-csv": "^1.17.0",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.17.0",
+        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.17.0",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.17.0",
+        "@comunica/actor-sparql-serialize-stats": "^1.17.0",
+        "@comunica/actor-sparql-serialize-table": "^1.17.0",
+        "@comunica/actor-sparql-serialize-tree": "^1.17.0",
+        "@comunica/bus-context-preprocess": "^1.17.0",
+        "@comunica/bus-http": "^1.17.0",
+        "@comunica/bus-http-invalidate": "^1.17.0",
+        "@comunica/bus-init": "^1.17.0",
+        "@comunica/bus-optimize-query-operation": "^1.17.0",
+        "@comunica/bus-query-operation": "^1.17.0",
+        "@comunica/bus-rdf-dereference": "^1.17.0",
+        "@comunica/bus-rdf-dereference-paged": "^1.17.0",
+        "@comunica/bus-rdf-join": "^1.17.0",
+        "@comunica/bus-rdf-metadata": "^1.17.0",
+        "@comunica/bus-rdf-metadata-extract": "^1.17.0",
+        "@comunica/bus-rdf-parse": "^1.17.0",
+        "@comunica/bus-rdf-parse-html": "^1.17.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^1.17.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.17.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.17.0",
+        "@comunica/bus-rdf-serialize": "^1.17.0",
+        "@comunica/bus-sparql-parse": "^1.17.0",
+        "@comunica/bus-sparql-serialize": "^1.17.0",
+        "@comunica/core": "^1.17.0",
+        "@comunica/logger-pretty": "^1.17.0",
+        "@comunica/logger-void": "^1.17.0",
+        "@comunica/mediator-all": "^1.17.0",
+        "@comunica/mediator-combine-pipeline": "^1.17.0",
+        "@comunica/mediator-combine-union": "^1.17.0",
+        "@comunica/mediator-number": "^1.17.0",
+        "@comunica/mediator-race": "^1.17.0",
+        "@comunica/runner": "^1.17.0",
+        "@comunica/runner-cli": "^1.17.0",
         "@types/minimist": "^1.2.0",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "asyncreiterable": "^2.0.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
         "minimist": "^1.2.0",
         "negotiate": "^1.0.1",
         "rdf-quad": "^1.4.0",
-        "rdf-string": "^1.4.2",
-        "rdf-terms": "^1.4.0",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.4.0",
         "streamify-string": "^1.0.1"
       }
     },
     "@comunica/actor-init-sparql-rdfjs": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.16.2.tgz",
-      "integrity": "sha512-37FizXW2XCtyRFq0vjCqTAzxnVVklYGoq3Rmn6sBelF6wKW7pqtHunBA3yOJfo5MKRVoFD04wHCbwaWC6xaYEw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.17.0.tgz",
+      "integrity": "sha512-IwwveaU/N0jauO7HEtWjBH/pp7JQxF+9V/ZBf/acG95/oJkFP2+CL5jjA6MiL6jAj7Fm14wIuDJdv3kfkKslcA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.15.0",
-        "@comunica/actor-init-sparql": "^1.16.2",
-        "@comunica/actor-query-operation-ask": "^1.16.0",
-        "@comunica/actor-query-operation-bgp-empty": "^1.16.0",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.16.0",
-        "@comunica/actor-query-operation-bgp-single": "^1.16.0",
-        "@comunica/actor-query-operation-construct": "^1.16.0",
-        "@comunica/actor-query-operation-describe-subject": "^1.16.0",
-        "@comunica/actor-query-operation-distinct-hash": "^1.16.0",
-        "@comunica/actor-query-operation-extend": "^1.16.0",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.16.0",
-        "@comunica/actor-query-operation-from-quad": "^1.16.0",
-        "@comunica/actor-query-operation-join": "^1.16.0",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.16.0",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.16.0",
-        "@comunica/actor-query-operation-path-alt": "^1.16.0",
-        "@comunica/actor-query-operation-path-inv": "^1.16.0",
-        "@comunica/actor-query-operation-path-link": "^1.16.0",
-        "@comunica/actor-query-operation-path-nps": "^1.16.0",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.16.0",
-        "@comunica/actor-query-operation-path-seq": "^1.16.0",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.16.0",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.16.0",
-        "@comunica/actor-query-operation-project": "^1.16.0",
-        "@comunica/actor-query-operation-quadpattern": "^1.16.0",
-        "@comunica/actor-query-operation-service": "^1.16.0",
-        "@comunica/actor-query-operation-slice": "^1.16.0",
-        "@comunica/actor-query-operation-union": "^1.16.0",
-        "@comunica/actor-query-operation-values": "^1.16.0",
-        "@comunica/actor-rdf-join-nestedloop": "^1.16.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.16.0",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.15.0",
-        "@comunica/actor-rdf-serialize-n3": "^1.15.0",
-        "@comunica/actor-sparql-parse-algebra": "^1.16.0",
-        "@comunica/actor-sparql-serialize-json": "^1.16.0",
-        "@comunica/actor-sparql-serialize-rdf": "^1.16.0",
-        "@comunica/actor-sparql-serialize-simple": "^1.16.0",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.16.0",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.16.0",
-        "@comunica/bus-context-preprocess": "^1.15.0",
-        "@comunica/bus-init": "^1.15.0",
-        "@comunica/bus-query-operation": "^1.16.0",
-        "@comunica/bus-rdf-join": "^1.16.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.16.0",
-        "@comunica/bus-rdf-serialize": "^1.15.0",
-        "@comunica/bus-sparql-parse": "^1.15.0",
-        "@comunica/bus-sparql-serialize": "^1.16.0",
-        "@comunica/core": "^1.15.0",
-        "@comunica/mediator-combine-pipeline": "^1.15.0",
-        "@comunica/mediator-combine-union": "^1.15.0",
-        "@comunica/mediator-number": "^1.15.0",
-        "@comunica/mediator-race": "^1.15.0",
-        "@comunica/runner": "^1.16.0",
-        "@comunica/runner-cli": "^1.16.0"
+        "@comunica/actor-abstract-mediatyped": "^1.17.0",
+        "@comunica/actor-init-sparql": "^1.17.0",
+        "@comunica/actor-query-operation-ask": "^1.17.0",
+        "@comunica/actor-query-operation-bgp-empty": "^1.17.0",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.17.0",
+        "@comunica/actor-query-operation-bgp-single": "^1.17.0",
+        "@comunica/actor-query-operation-construct": "^1.17.0",
+        "@comunica/actor-query-operation-describe-subject": "^1.17.0",
+        "@comunica/actor-query-operation-distinct-hash": "^1.17.0",
+        "@comunica/actor-query-operation-extend": "^1.17.0",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.17.0",
+        "@comunica/actor-query-operation-from-quad": "^1.17.0",
+        "@comunica/actor-query-operation-join": "^1.17.0",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.17.0",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.17.0",
+        "@comunica/actor-query-operation-path-alt": "^1.17.0",
+        "@comunica/actor-query-operation-path-inv": "^1.17.0",
+        "@comunica/actor-query-operation-path-link": "^1.17.0",
+        "@comunica/actor-query-operation-path-nps": "^1.17.0",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.17.0",
+        "@comunica/actor-query-operation-path-seq": "^1.17.0",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.17.0",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.17.0",
+        "@comunica/actor-query-operation-project": "^1.17.0",
+        "@comunica/actor-query-operation-quadpattern": "^1.17.0",
+        "@comunica/actor-query-operation-service": "^1.17.0",
+        "@comunica/actor-query-operation-slice": "^1.17.0",
+        "@comunica/actor-query-operation-union": "^1.17.0",
+        "@comunica/actor-query-operation-values": "^1.17.0",
+        "@comunica/actor-rdf-join-nestedloop": "^1.17.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.17.0",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.17.0",
+        "@comunica/actor-rdf-serialize-n3": "^1.17.0",
+        "@comunica/actor-sparql-parse-algebra": "^1.17.0",
+        "@comunica/actor-sparql-serialize-json": "^1.17.0",
+        "@comunica/actor-sparql-serialize-rdf": "^1.17.0",
+        "@comunica/actor-sparql-serialize-simple": "^1.17.0",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.17.0",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.17.0",
+        "@comunica/bus-context-preprocess": "^1.17.0",
+        "@comunica/bus-init": "^1.17.0",
+        "@comunica/bus-query-operation": "^1.17.0",
+        "@comunica/bus-rdf-join": "^1.17.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.17.0",
+        "@comunica/bus-rdf-serialize": "^1.17.0",
+        "@comunica/bus-sparql-parse": "^1.17.0",
+        "@comunica/bus-sparql-serialize": "^1.17.0",
+        "@comunica/core": "^1.17.0",
+        "@comunica/mediator-combine-pipeline": "^1.17.0",
+        "@comunica/mediator-combine-union": "^1.17.0",
+        "@comunica/mediator-number": "^1.17.0",
+        "@comunica/mediator-race": "^1.17.0",
+        "@comunica/runner": "^1.17.0",
+        "@comunica/runner-cli": "^1.17.0"
       }
     },
     "@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.16.0.tgz",
-      "integrity": "sha512-KWuAKG8S+IwonyecNjqrO5dlSKSVmR1cxP117/DEUPIltXl0IY2W3Q/HKRRZ+DXwV/LRMExIXILdUkZgYUSnAw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.17.0.tgz",
+      "integrity": "sha512-9FJB4NVbR7SiqNzm2ljudYDebXrw+6242acLBVPp7M/kr9WAFwYKRUMTxwQNFnasmiuBvEJ/Ic55135zeQbJ3Q==",
       "dev": true,
       "requires": {
-        "sparqlalgebrajs": "^2.3.2"
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-ask": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.16.0.tgz",
-      "integrity": "sha512-zlWYPh7GoIw7epzcORfDWwRFsfLciJGVSaCR2C46AZj8CctApf+mzrRDY7H3WSETyTc6s9T1fiDzGjBY/P3TbA==",
-      "dev": true
-    },
-    "@comunica/actor-query-operation-bgp-empty": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.16.0.tgz",
-      "integrity": "sha512-C8q0YKNcIbMZ1KWL1juCoTbppYQcI3/0qlp/boBD1w8yeNVt2ytxB0cKsdVilvLVVcooISJJKNn4j8uGqOJsZg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.17.0.tgz",
+      "integrity": "sha512-aZ3OwCPNB91UFI2Nl27PYzBJEnKD7sHyJ2VshSbHAag2pYUW1Gln3lgw3RxbHtiVNKlGu10KiyQ32gQVVUwuVQ==",
       "dev": true,
       "requires": {
-        "asynciterator": "^3.0.1",
-        "rdf-string": "^1.4.2",
-        "rdf-terms": "^1.4.0"
+        "sparqlalgebrajs": "^2.4.0"
+      }
+    },
+    "@comunica/actor-query-operation-bgp-empty": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.17.0.tgz",
+      "integrity": "sha512-+AKeuUh5LGzVkdsROFrBTBpiYsUozT0qcIgeBL0DISZmfX8nrRVO+8S/oEm7dfbIBGgAWiKevz3AS2nAmb3nWQ==",
+      "dev": true,
+      "requires": {
+        "asynciterator": "^3.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.16.0.tgz",
-      "integrity": "sha512-8zB8ajT7z6nYDge9//7zP0sziKmnCFLVVtqqyacSQ8Yu9jl15b42rqMiZ0ty9c3qZncH2DagqiTd/5VCJP3nMg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.17.0.tgz",
+      "integrity": "sha512-QXnqcyNRA7pE7L9nsm8DO80ja7QhqqYzidW3192Zot8oQlpTItH8Kv4ZZRBuuODe63/uFooSB1zHXSXItOWPKQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "rdf-string": "^1.4.2",
-        "rdf-terms": "^1.4.0"
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-bgp-single": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.16.0.tgz",
-      "integrity": "sha512-nUcGlq9uJCl5O7rGnFCrFeHrWSRD7hZW9QU+B7tCoSbJoUrKS9hBKkDO6xUHmsmztRKfzHgMO9LFDvmc5jGKlQ==",
-      "dev": true
-    },
-    "@comunica/actor-query-operation-construct": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.16.0.tgz",
-      "integrity": "sha512-c4tLLcl7T1JYCg790LEu9Ijn3c7i2yd2uKJ9E2oytx6KLeW0YQeEaiLZ1hn3XDlQHMvfYeGznd4Y+X8632+Faw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.17.0.tgz",
+      "integrity": "sha512-gI/3cCZ1fMc5Qe5tuKlbGXqB54pXPESvInOCi6Kd25Dy+COSqoPqytUKFLHD23MDBDoI23ZN6LC9JV9bRGWL5A==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "rdf-terms": "^1.4.0"
+        "sparqlalgebrajs": "^2.4.0"
+      }
+    },
+    "@comunica/actor-query-operation-construct": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.17.0.tgz",
+      "integrity": "sha512-t9Spn99SQbFl1ik/BdVKVPkmy3yVkxxacWmLe5Sue5G0Qj7fs5KnSHEuZPYekpsjy9PMTgHRJuI6Y2XByyPv5w==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-describe-subject": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.16.0.tgz",
-      "integrity": "sha512-F5x0AU/7K9Zw6o5/y2AWsX5G3YPyLoDekWm1bHyztnHD21WFGsOgAt7R3XOJLU4/d9Mc2TpDOj17bttplJRXSg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.17.0.tgz",
+      "integrity": "sha512-Roe4fHrjlBK4IulrHHHzBYpVt5BNUVNSU9ESPN6+6L0dQHw7PAeDe8mySyBB4Ua9ebSDaR1PTTC5HzxUn2Qxww==",
       "dev": true,
       "requires": {
-        "@comunica/actor-query-operation-union": "^1.16.0",
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1"
+        "@comunica/actor-query-operation-union": "^1.17.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-data-factory": "^1.0.3",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-distinct-hash": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.16.0.tgz",
-      "integrity": "sha512-/SKXl7lFUlJ83yL81lD3RyzqkV5ONqUiqR8d1D0Vob/m8DI7ynDp8f5x74ocBLdrhFADJvGlVl8703AjJzcD6w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.17.0.tgz",
+      "integrity": "sha512-N5+4/ye+PtuQmPJEX2Giqz3l4a1yJnqHddciT7LaidzG0SJW6Kbt0VfnSUOFlWSHRYQobIbfJfq5Fj+QJnrrGA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.16.0"
+        "@comunica/actor-abstract-bindings-hash": "^1.17.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-extend": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.16.0.tgz",
-      "integrity": "sha512-xad5NhPZ4KJsk3DTlG6mb0ZEX6LccCRjhFEVZsNT4qr1DPTqD5MaeE/SfjFADCwDniy5gZTxn6AQnQ1LsC52Eg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.17.0.tgz",
+      "integrity": "sha512-RWBqm43KWiRtj9cxY9S+wRy/l3GfFSBKWEw949S3box8mMFQX+hfQccyYR4WCP+FOtIUSkulloUWIZegBdVK/A==",
       "dev": true,
       "requires": {
-        "sparqlee": "^1.4.3"
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0",
+        "sparqlee": "^1.5.0"
       }
     },
     "@comunica/actor-query-operation-filter-sparqlee": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.16.0.tgz",
-      "integrity": "sha512-96ttlUQkBpkiUlXnClvjEaYHtEL8gCVzhOMcMLxuOAifwgv7I6Qe5WQT8QZkJbXbbwNvelXYC4Cs37p85nHSCw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.17.0.tgz",
+      "integrity": "sha512-kPq2waMWhWV/TsqERwAZmDAn5SQwP6psODJn9EWytQ/25jiYyRQq/dUQPahV37WY4hO8z4lG34cmE8Xh7BokeQ==",
       "dev": true,
       "requires": {
-        "sparqlee": "^1.4.3"
+        "sparqlalgebrajs": "^2.4.0",
+        "sparqlee": "^1.5.0"
       }
     },
     "@comunica/actor-query-operation-from-quad": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.16.0.tgz",
-      "integrity": "sha512-qyjSrxmi0WSlxMbZo2djOfUD+2Jkm7s4JOW36ua8JBbSuGAbHwFI3xYSWiWYmLCMQEp3YgqHrTKWeGDSnqxnJQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.17.0.tgz",
+      "integrity": "sha512-r9Qd4aSRpAQHy3WOpeGcQcfDpj91SYZY6v9wqZa3GmnUvesT36yFfbAFiMOpLoDHf2ki8nL6MBx75XhmqAn24A==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "sparqlalgebrajs": "^2.3.2"
+        "@types/rdf-js": "*",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-group": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.16.0.tgz",
-      "integrity": "sha512-xwmoNsfjcsS04s3lLlf6dua81ywFNqOU77g61tZEveCAKyC5fN6rQZM8eLBa87z7HhHLHF42V1TVXh3PD46HaA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.17.0.tgz",
+      "integrity": "sha512-PhbCxOo5/lNBkrL9SJjUJee0BgjR9xNVNdsYxfNeo6XpZrGjFGZ3QxiO79pDvrOaEypRwLHnDLao1EzVRIH7ww==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.16.0",
-        "rdf-string": "^1.4.2",
-        "sparqlee": "^1.4.3"
+        "@comunica/actor-abstract-bindings-hash": "^1.17.0",
+        "asynciterator": "^3.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0",
+        "sparqlee": "^1.5.0"
       }
     },
     "@comunica/actor-query-operation-join": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.16.0.tgz",
-      "integrity": "sha512-3lJt1dTrBm4ogRwCyEPwqOrJ/QfEEYu5tHUClpiP3vG0L1tmN+wRfewAxU7P8o0Rec0QkqICAMRf252tM0ftgw==",
-      "dev": true
-    },
-    "@comunica/actor-query-operation-leftjoin-left-deep": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.16.0.tgz",
-      "integrity": "sha512-fVVdcMEFvQpU8eKQyDys7q6jL6SosHdSs2j5ARPmXvY/hzl68coIb4D0JmMIIWmk87TDcc9VUH0mcnHI5f7Eqw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.17.0.tgz",
+      "integrity": "sha512-Kwsr89AVDAxHjPzSSQkOQEjYJzQN0XBzxaFHsJhYEJ/TUFzFVhppyENFiRB52DPFPBWeG/0PFssFbFM6bNpf4A==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1"
+        "sparqlalgebrajs": "^2.4.0"
+      }
+    },
+    "@comunica/actor-query-operation-leftjoin-left-deep": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.17.0.tgz",
+      "integrity": "sha512-f0J2HH8Sm1uwUM1H7G0NIvnVScDdDRUfiUttq2pLoblyrcmprr41ZZP2All1zUhN+Y+aSGn5h8eV+XDvJt54LQ==",
+      "dev": true,
+      "requires": {
+        "@comunica/bus-rdf-join": "^1.17.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.16.0.tgz",
-      "integrity": "sha512-dTNcGe4LTwgJcvAV2TZA9lF6gmvtcQDFm+4UEiY5ehtgOD/Quh39AixYSXTNOsmMmGBamr5iBfk1ABgRwAmzyg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.17.0.tgz",
+      "integrity": "sha512-tdNTn+/k7zdnhhM9AoZx9knCg9hjRoNBrOIGZZFxgsd53kgwAuTXZ6fX7GMsKsMK09BXeXhQUgMtIXHqNi1HFg==",
       "dev": true,
       "requires": {
-        "sparqlee": "^1.4.3"
+        "asynciterator": "^3.0.3",
+        "sparqlalgebrajs": "^2.4.0",
+        "sparqlee": "^1.5.0"
       }
     },
     "@comunica/actor-query-operation-minus": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.16.0.tgz",
-      "integrity": "sha512-PeM5FouB+BJMU2QYB//SK9O5LCdielQnrr+nTWXyznrx1kpBqMX7Elzmim5huhKY3Y0WfotL6rGsE5DEjdRE1w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.17.0.tgz",
+      "integrity": "sha512-cJOopwer550KnCUirFgsYwjabt/QYzpCaVsYvJ7e+4ivHxkDMtUdKqYyfrgaIx7ZXebngBhFI25JutrX8lNVIg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.16.0",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1"
+        "@comunica/actor-abstract-bindings-hash": "^1.17.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-orderby-sparqlee": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.16.0.tgz",
-      "integrity": "sha512-mRubrkxjevfsrr3sMn/scVg9pveNDLammx5jtrBDm5IKkL2muTH6HGduLCmT/zONBkxUZy2uOiXQgxHXrtznsw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.17.0.tgz",
+      "integrity": "sha512-YYPido8qCiaiIPGduMiDpzsB2WW5G0wshATZroHwMEaktwTr5kOtWt1tq//mRfIyxm15VvsK8gja0Djwh1LeEA==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "rdf-string": "^1.4.2",
-        "sparqlee": "^1.4.3"
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0",
+        "sparqlee": "^1.5.0"
       }
     },
     "@comunica/actor-query-operation-path-alt": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.16.0.tgz",
-      "integrity": "sha512-VJiGYoupy41Rcbbf4BymERWC5U7OjVtSe0JuSkHoOmKl9HcXQo+dGur+XJpbKz391rDY+BB2djH3Bht1YmrYig==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.17.0.tgz",
+      "integrity": "sha512-bFoS7ulBfbR6dUfrBWnslsH5zBconmdCTRShNFLjEMB5KA9RuCOt+apfK+bzPQSi2ft9bFqaBEqVuiQg3YixEA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.16.0",
-        "asynciterator": "^3.0.1",
-        "sparqlalgebrajs": "^2.3.2"
+        "@comunica/actor-abstract-path": "^1.17.0",
+        "asynciterator": "^3.0.3",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-inv": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.16.0.tgz",
-      "integrity": "sha512-xVWLGiaIbuv2vudAFVgotHx/YCNQ+deflpgSyg5RsUU7cnqj3njkt4Iq8lX+8Sdwjmr10UIAqXPVMHKsRCRKzA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.17.0.tgz",
+      "integrity": "sha512-R4hfjLlVqfJYgtMEGpBP8FnszIEieuYOk6+oka7B/+reDOjyU0yfi3/PjtC4rx+qoYIZDkT9x95YXBGitjW8Zg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.16.0"
+        "@comunica/actor-abstract-path": "^1.17.0"
       }
     },
     "@comunica/actor-query-operation-path-link": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.16.0.tgz",
-      "integrity": "sha512-YCPgTQGfQCtp88OneFYTyXBG9pHuHs5Plfmj3BZP0fhbIXhn6ywn4LP5NXaVukJFCDwCFRWL9Pd1aZ5N0p9tNQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.17.0.tgz",
+      "integrity": "sha512-fpOiAY/LMh4HrmTsgkROeKFozItt40rkvjLP2fayX7tuk2oplmjjgG4dn/jJ0/XdYEQ1TRfh0L25qoFncOZi5Q==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.16.0",
-        "sparqlalgebrajs": "^2.3.2"
+        "@comunica/actor-abstract-path": "^1.17.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-nps": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.16.0.tgz",
-      "integrity": "sha512-S/CDgtnLQC+3qndBOST1y+AvUsCc/nh08+4s91K9RqkuQwV5/1Sl5B0aThMItazTKuUPj04ujH+PCOArt1+sbQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.17.0.tgz",
+      "integrity": "sha512-Vj7kIRIpRyoA4PQU9WbghiI5MXCtU18Db259k8DhWCEubqMonQtWQPVg0CVRjBm9kf9jEKgEU9mvrLNvht8JIQ==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.16.0",
-        "rdf-string": "^1.4.2",
-        "sparqlalgebrajs": "^2.3.2"
+        "@comunica/actor-abstract-path": "^1.17.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.16.0.tgz",
-      "integrity": "sha512-RpjvSeua4hsSISonfK53qMlWizQ9ou208zpiGpGLamDAVpLj4pgKAQ3ksfWM+GR2sXVDiCIAvpszJkSEa9NY/w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.17.0.tgz",
+      "integrity": "sha512-HNj3KQc/b9Uxir9ngGkvFPZYroW93HDvXpJNkaUjTbDpsRqhQ+uRvlI+Vy4X9c9npNhSDt+3QAJWtGgWL8/gpA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.16.0",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "rdf-string": "^1.4.2",
-        "sparqlalgebrajs": "^2.3.2"
+        "@comunica/actor-abstract-path": "^1.17.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-seq": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.16.0.tgz",
-      "integrity": "sha512-/vbN8Y8a+Sb1XcP796YxwahiD2b3euxHBu1h4pLu0oTKg6KTqbjHjbGQhxe95sWU3HKoH7F7VErTjlX8Wl29Kw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.17.0.tgz",
+      "integrity": "sha512-1BFExVqPRTmZqrxh9r716tEAm0sVHfhghH3RNTQQon7Hq8QNHrGn3pfjKcX3ESdLuWTE6DVHXqdBCcpBQ4bVNA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.16.0",
-        "rdf-string": "^1.4.2",
-        "sparqlalgebrajs": "^2.3.2"
+        "@comunica/actor-abstract-path": "^1.17.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.16.0.tgz",
-      "integrity": "sha512-Z5NhpB4MEZHk3yhInOHILWiNzK+ZGWr+HvjYD5PtDHtbWWgE3nrxbuNhdXs1iXgaJsZWlp7ziE+H3ms4GcYjUQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.17.0.tgz",
+      "integrity": "sha512-fKe6WEz/CoEWjxgTf2aSvI0ZSVRseST8EdGVadu86Jr+jYdyif/kwzZFjqm1BNWKaDuReJm0z8Kzq4gPYjDWwA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.16.0",
-        "rdf-string": "^1.4.2",
-        "sparqlalgebrajs": "^2.3.2"
+        "@comunica/actor-abstract-path": "^1.17.0",
+        "asynciterator": "^3.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.16.0.tgz",
-      "integrity": "sha512-pGzrXcXsm6l0RKF9SfC8njqw72XiOns/chiuKegChqTQd00DubTJVHmfb2HUuNyiNVJ2BrjwYdAysP1gI93D5w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.17.0.tgz",
+      "integrity": "sha512-Gj1pMvz4IUe4UbntvHPImMge7T/hWGpOVCOSGZtE79WjHL7e3rjQwhci+0AYD8v+i33QZIDSxhxf6ly3aHe3zQ==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.16.0",
-        "asynciterator": "^3.0.1",
-        "rdf-string": "^1.4.2"
+        "@comunica/actor-abstract-path": "^1.17.0",
+        "asynciterator": "^3.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-project": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.16.0.tgz",
-      "integrity": "sha512-uTi+GmB04RnZ7Sw3XJst8tmPtiqLmT1Z4+zTspTgnWwndeWzdw7w7v6apCZDoivvPLi1Jq/7hGNn6+3FsIGp+A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.17.0.tgz",
+      "integrity": "sha512-cBKTnlq12uRN6AwgvT1wWfZcS4dxkeoYrNX105NsCWFS5lSYQAjenzBaFJ8at7X623tvjcQuk0F6LfcTlPov7g==",
       "dev": true,
       "requires": {
-        "@comunica/data-factory": "^1.14.0",
-        "rdf-string": "^1.4.2"
+        "@comunica/data-factory": "^1.17.0",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-quadpattern": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.16.0.tgz",
-      "integrity": "sha512-QFml3MgYd5nmnsPHoDvOcx/StY+4L0ix5C1q5h8jagwIbcuRSfo1Ay0gLMlbEDuZkzrHhkN9o6OsSMTVuXsiEQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.17.0.tgz",
+      "integrity": "sha512-GwRaZbcmhFvnRYZt2qdJY9qxvxd80k5UH6+PixbANQm5VdUjG3f8RQbBo4dzSsSGcrBp77HVgkZfZj8lyforgQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "rdf-string": "^1.4.2",
-        "rdf-terms": "^1.4.0"
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-reduced-hash": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.16.0.tgz",
-      "integrity": "sha512-zE1K+d6HBhGsvQQd/XGYUgpue/aSKeHbdB2r+yzEels0ShPYxogVV69aHQAUxPXvz+kbPEzqwTWz5a28lJW+cw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.17.0.tgz",
+      "integrity": "sha512-LQt+T2qxDV3IcMC8R6PXUkAl9W7WcqbIq1tZ49gqTG8GhJ19X7SUTG8w2kf2G61bN37I2F9msgg4IFuh/UKlNA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.16.0",
+        "@comunica/actor-abstract-bindings-hash": "^1.17.0",
         "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0"
+        "lru-cache": "^6.0.0",
+        "sparqlalgebrajs": "^2.4.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -3394,59 +3426,68 @@
       }
     },
     "@comunica/actor-query-operation-service": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.16.0.tgz",
-      "integrity": "sha512-UTWmUZa59o6DaPqHjtFM8CES3/vlis6psAW5Wt4Bw+5sgK2XZ1EWFNM/BbQG5m0OetzgDJS+BRVbsJNDGdHRdw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.17.0.tgz",
+      "integrity": "sha512-HMjbujf7DmuRMbYPUGjBlt863ilUkR4QjwvOFz4Q4eThGGSOAkXkC3h4hpc2ir6xjv2tLBB73RmKKGVGjrQ4qg==",
       "dev": true,
       "requires": {
-        "asynciterator": "^3.0.1"
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.17.0",
+        "asynciterator": "^3.0.3",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-slice": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.16.0.tgz",
-      "integrity": "sha512-vFo1HVlz+0Jz2a8ppPU4tXPbSL/G9TILPSyvSJjXpQpvOQRih7m9AFeXUjGtJ6sFo5SryAkgynfk6jO0Co9tzw==",
-      "dev": true
-    },
-    "@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.16.0.tgz",
-      "integrity": "sha512-3VxGRHjwWBP23ezSKVgFJG5/nj5pMhX++8d3w3WFCC5kss+p7Qnq9P06sz/42Ya/hY/CGJM4iramadGOTnbEmw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.17.0.tgz",
+      "integrity": "sha512-dvOzpGno8aw29Wtf1EgOq2llOU7f5t57SQj+rhRy88bY6KnwJ/Z9E3avdbJE/n2mNbryYJyRmzJR0OYU+tWjxQ==",
       "dev": true,
       "requires": {
-        "@comunica/utils-datasource": "^1.16.0",
-        "@types/rdf-js": "^3.0.0",
+        "asynciterator": "^3.0.3",
+        "sparqlalgebrajs": "^2.4.0"
+      }
+    },
+    "@comunica/actor-query-operation-sparql-endpoint": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.17.0.tgz",
+      "integrity": "sha512-avN+002n6wKPju3QCjLlsVqxxA01LDsJ/GdtZQ8O4k82H9S8mUJ68lUvb/u+Nwc6kMdDNtPmSXJjZ2VFRnuT/g==",
+      "dev": true,
+      "requires": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.17.0",
+        "@comunica/utils-datasource": "^1.17.0",
+        "@types/rdf-js": "*",
         "arrayify-stream": "^1.0.0",
-        "asynciterator": "^3.0.1",
-        "fetch-sparql-endpoint": "^1.6.0",
-        "rdf-string": "^1.4.2",
-        "rdf-terms": "^1.4.0",
-        "sparqlalgebrajs": "^2.3.2"
+        "asynciterator": "^3.0.3",
+        "fetch-sparql-endpoint": "^1.7.0",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-union": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.16.0.tgz",
-      "integrity": "sha512-x3eZA7T004Pdf+rEMj5ts7qs66+FFBddKnWdT10fRDkXoRTTStoSsw2oW/fk8Il9FcEAQVtNXur7ehVvzV5S5A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.17.0.tgz",
+      "integrity": "sha512-1hpfe0kFU3n//qSPi7FbfaeMHDGeO2qeFV0qltHE0MgH/v024mk6kt0i7Fa/LYJ48/fHB4s/xAztShdgpfcRIA==",
       "dev": true,
       "requires": {
-        "asynciterator": "^3.0.1"
+        "asynciterator": "^3.0.3",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-values": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.16.0.tgz",
-      "integrity": "sha512-X2KE3DNiKtK1sjLkakDgfTZs2paMgNu54zp6wAlIWzg5QVj+iDk+XM5wx8JFI+Mrro4oRN9Gl9TOjGupNjLnxQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.17.0.tgz",
+      "integrity": "sha512-c8mqfIWzSdYfNL+frrXE28gss2WiIBmpRqBx1rC/WeW1+ioR3ZCQ2UixqzgI/29SvY25pLvMESrzA2/TSxIr0g==",
       "dev": true,
       "requires": {
-        "asynciterator": "^3.0.1",
-        "rdf-string": "^1.4.2"
+        "asynciterator": "^3.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.16.0.tgz",
-      "integrity": "sha512-IKSw5jjQLIDkbd7eX3Sw0oMuPBujQ4JX6UMpDA846T4lOZcUBTovp0PPKL4zyUd88Ea9a84Qn6uREOWed4nKvg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.17.0.tgz",
+      "integrity": "sha512-L3xWBnBGOiXcF3LXC3AUwNTRqJv7v4QwjOlc4WzUuV2M7Ce0cxegmIglDr3oAYJNzBfJosPpWYHdpWG6dWxW9A==",
       "dev": true,
       "requires": {
         "cross-fetch": "^3.0.5",
@@ -3454,211 +3495,226 @@
       }
     },
     "@comunica/actor-rdf-join-multi-smallest": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.16.0.tgz",
-      "integrity": "sha512-03oN4MqKBP0eVtMPyJT/PrYR7znDXU37E6sHqW/VGqws5A+myz4G/mxSSOjVE6csN5bt2wNrfpzv9J7hjmHyVA==",
-      "dev": true
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.17.0.tgz",
+      "integrity": "sha512-IXztYTgnLjc/OaOmbYu28nUzrZw7ypdFM3WcTFXLHS+wmLkhOHF+OtCDrMhR9J4OlHUUSgASFf8/Dcjp2YiErA==",
+      "dev": true,
+      "requires": {
+        "@comunica/bus-query-operation": "^1.17.0",
+        "@comunica/mediatortype-iterations": "^1.17.0"
+      }
     },
     "@comunica/actor-rdf-join-nestedloop": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.16.0.tgz",
-      "integrity": "sha512-f+2x4hgMGWkIroGc9ld3o/dFKZIgvV5DVRI9AGsJR+AZaDmet7nydKs8fw/6nEjMfYIvuNlGVgmSEsLgsAa7sA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.17.0.tgz",
+      "integrity": "sha512-d4dnaLg/g19hAj/yVQgvDhBKLbfN/lsX1u98eZPWdt7JAHjgtEx2m4oAIfiUmrPKm15Y2174oCYMyQbP1wPUew==",
       "dev": true,
       "requires": {
         "asyncjoin": "^1.0.1"
       }
     },
     "@comunica/actor-rdf-join-symmetrichash": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.16.0.tgz",
-      "integrity": "sha512-d1Sszprnc+aJQt1cjycroGAkhAa2fMyECelcJGqwKWpVAXT/nsbOB0Ixb0eKTF4uGlYFrdA/OSG7frwdAORepg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.17.0.tgz",
+      "integrity": "sha512-2NYIVSY6G8leZv3KuGWNwDTyMJzbb/VogLqLziTdHE8z+er1/BbEj2F3zwMgPbLkHO+I7Mb43U0XSJVTggxb7w==",
       "dev": true,
       "requires": {
         "asyncjoin": "^1.0.1"
       }
     },
     "@comunica/actor-rdf-metadata-all": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.15.0.tgz",
-      "integrity": "sha512-Ax+q0igPmDQeriFL4hDMQWQPV4tsTzyboqnuXqj9U84YXmJ3y+5a5Wh/35odR3W31SwMrs56jYNIpZBKwx0+RA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.17.0.tgz",
+      "integrity": "sha512-RyhFZm0LdYuXJ2BQwNDmUghKkNSn8J5st65m9+qW9JYdeM/j9Sr7+22QaCkv51Lg4bGlY5vvoV1yLzYAI3Ewsw==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.15.0.tgz",
-      "integrity": "sha512-Ih5OJQGfmJe5ihMeFwtWhWKSCxLXEKID3i3NGm8MgiFFbEzLAAf1YLLIK57cW88vahY+3YkPZ7tq3FeIeAi3tw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.17.0.tgz",
+      "integrity": "sha512-2HQW/UsFc5WDwcrQhLZH+RAGn7QPwXE7mgY0zeFbEgJobo/tYWAK0mo1YL/cRrCJbHR2vF47rzTkK2ZM3Jn00Q==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
+        "@types/rdf-js": "*",
         "@types/uritemplate": "^0.3.4",
         "uritemplate": "0.3.4"
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.15.0.tgz",
-      "integrity": "sha512-3qNJWsSo0xR8xt7MEFD7rVlQXiBTLddzUK/5lX1A4dB3jk20a+c62WltctWYiIFtyCs0qYluAJ8xuJ2ItOlP7w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.17.0.tgz",
+      "integrity": "sha512-WjRQDgovzYgyGsRPg0D5QZhDsmMUazz1+qVSD1MP/bjNwwdUTenWGlTf8FcDmkrspm+4Y7BiTRgbo0dXU4vj2g==",
       "dev": true
     },
     "@comunica/actor-rdf-metadata-extract-sparql-service": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.15.0.tgz",
-      "integrity": "sha512-CCikTWHa8nNUfmDHPGjgTH60XGcOJtkckzZXdk6kG4rMKXocsj86/cwzYM89P58LOMKy4IFfsSpoEqKIhn2gog==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.17.0.tgz",
+      "integrity": "sha512-BL8J5F6+HhgO9xImHsNONjkngunYVp+p2Th5KPVPtSKSM1WlQsva7d/w3GgMym38kz7C60mYKFR/ZmLvad2WJw==",
       "dev": true,
       "requires": {
         "relative-to-absolute-iri": "^1.0.5"
       }
     },
     "@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.15.0.tgz",
-      "integrity": "sha512-7YRtw2us52nXYcaPyk8q/rCopioCS5LEVDEteD3RqCd7KMVhg+VZYU0iD5cMF9tyYr8NoXdm1/CYxTnSZE/LNg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.17.0.tgz",
+      "integrity": "sha512-if+XTXB7qnr2g6QDed0N0kiXq0Jge5F6mNM8ze2+dQUqPHfxIxqB+7w6CsuX92JA9rhRxkH4kE1HOCFJy+cnYg==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-rdf-parse-html": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.15.0.tgz",
-      "integrity": "sha512-eC43jtLqY3wfA6aRim83l+3NfoMQCZv/lPP2MvqxY04/Rk77DdqKtKS2GfYrIBc8aqDOoreVgiBQG5TzPzm5Ew==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.17.0.tgz",
+      "integrity": "sha512-BfBaajyEeq6GhGcUcwbDZA91mZTiotbeh3L0L6pD3Al81FQUtBbHTTgNUKd8H2E5R0G3gPtXm0Xz8YMmSIQBfQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
+        "@comunica/bus-rdf-parse-html": "^1.17.0",
+        "@types/rdf-js": "*",
         "htmlparser2": "^4.0.0"
       }
     },
     "@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.15.0.tgz",
-      "integrity": "sha512-1rA7YCjY1v7/1oRKzthVw633HZmHux96SQW5j+FIJTvX4GoBvf1seS082HY7WQGRpZVgLxOUxtAOQcp7zT4dHA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.17.0.tgz",
+      "integrity": "sha512-Rrmmfwbu0dh95E5nKECGrTzrS8JuXeFCiRoTrqfnFPke4BvMIrilkwZyHKzELMpfnOZfGzmtolM51Nhl+OQ6GQ==",
       "dev": true,
       "requires": {
-        "rdfa-streaming-parser": "^1.1.1"
+        "rdfa-streaming-parser": "^1.3.0"
       }
     },
     "@comunica/actor-rdf-parse-html-script": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.16.1.tgz",
-      "integrity": "sha512-IYagk0RzIQEzj/78KvoICDgOiPnwvj44S/PH2ha++o9Se0FgTxRjHrWTluETiczOcvrV54TeVh0YDYJck+xz/w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.17.0.tgz",
+      "integrity": "sha512-FofW13U++ULqlT5/XX+AWNNOXpbiBoWSbZuhiNnvGkCp+CvdxzWD09XMwDtqX7pua3TE+e/bgxBOLJT/wDLxYg==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
+        "@comunica/bus-rdf-parse-html": "^1.17.0",
+        "@types/rdf-js": "*",
         "relative-to-absolute-iri": "^1.0.5"
       }
     },
     "@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.16.0.tgz",
-      "integrity": "sha512-LtAIv75bhHe2teN0vjWZ6EkjwnK6Yw56Q1ZuxgrWZLGrbdRF6YZuXglW+IqWeZ45tIUqhweS83k17/9fR3UK5w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.17.0.tgz",
+      "integrity": "sha512-n7DqhgrqQ2PI5LN1JhhlsjyS+LSsLS5fKX/s31NFB/C2ShqbWZxpmzW19dsTXb2KYRnDkRlq1hvnvORMwzOhdQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "jsonld-streaming-parser": "^2.0.2",
+        "@types/rdf-js": "*",
+        "jsonld-context-parser": "^2.1.1",
+        "jsonld-streaming-parser": "^2.1.0",
         "stream-to-string": "^1.2.0"
       }
     },
     "@comunica/actor-rdf-parse-n3": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.15.0.tgz",
-      "integrity": "sha512-YWk7XSDN8GDOFL+u5PtadZmIUzAh5ZUYB/LwXLENeymIgWEaSvJo5H4QqdGmnJFArlgXX2Thk8jTvbtubiNTvw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.17.0.tgz",
+      "integrity": "sha512-mt4iOVqMYrj9WVJL9F/MAShgUd82GweirtWdisJ/9FgmKTbfuTpsoZJ8vdChw133EskXYaCbzD0SuYcMvvrxHw==",
       "dev": true,
       "requires": {
-        "@types/n3": "^1.4.2",
-        "n3": "^1.0.0"
+        "@types/n3": "^1.4.4",
+        "n3": "^1.6.3"
       }
     },
     "@comunica/actor-rdf-parse-rdfxml": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.15.0.tgz",
-      "integrity": "sha512-Rec0dnaTW95Mx91cfQPBkDkgEhoFd9J36FtiJAotLFPOiXp4YsTEZGQNSODTbhchfaTS6HDTFnETQ6GbmutaCQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.17.0.tgz",
+      "integrity": "sha512-DQCP+0urZplZAd3qu8AjPiEV6MiAMO7EPvT0iH8Q1qWV+L/LHPqpAdF6d8Af6+jHWhV5MB+6cUSqJRrjL7MLqQ==",
       "dev": true,
       "requires": {
-        "rdfxml-streaming-parser": "^1.1.0"
+        "rdfxml-streaming-parser": "^1.4.0"
       }
     },
     "@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.15.0.tgz",
-      "integrity": "sha512-34CI/f/JQTEfrnxyqB7Y+EhkhW0tTMsHoC8yu+Y6AtSVdj2FYkSR+GmAk9F65JVnm/RC9uh1T7yT5yJMVvmgiQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.17.0.tgz",
+      "integrity": "sha512-MtTnL2uZ3/Vb/JkjN7Q1n6rhsFih0d/rFGFEFVuuxJF6L2HAjxrCvevFYXrB787SpG3T5Il4XBL588ZHj7y5Uw==",
       "dev": true,
       "requires": {
-        "rdfa-streaming-parser": "^1.1.1"
+        "rdfa-streaming-parser": "^1.3.0"
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-links-next": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.15.0.tgz",
-      "integrity": "sha512-TgQurH1G50rdgnQ9WCWchYrUDMk+379oVuha5JISwW5Dc33/wVjR+hoIkrAfKx/kIi7846mcEHO4qNQ5V818hw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.17.0.tgz",
+      "integrity": "sha512-rMUfy93Acg64oRk7hv8xnebB1P1PXqa8cQ0JbSb0oEzK1ONhwXO+4gYquAurWL/ak+POx/1ujXEPPpqbKIdPvQ==",
       "dev": true
     },
     "@comunica/actor-rdf-resolve-hypermedia-none": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.15.0.tgz",
-      "integrity": "sha512-dgCFXKbmY9UKSaczpmdVFeSNNcotgWJavC979HQO40zjq6tg3kRDT82M0ucjuDB7fIglzA8xQYTvbjIWYNrm4g==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.17.0.tgz",
+      "integrity": "sha512-oXyZuFr2hSbTd5rdMruOIaahaTwjELZdlKrikI4t8rBcDGrNiEksogUYzlkZMtAniUtDM48aIOMDXBdMfesw7w==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.17.0",
+        "@types/rdf-js": "*",
         "rdf-store-stream": "^1.0.1"
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-qpf": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.16.0.tgz",
-      "integrity": "sha512-ikOdP68hwoG9jFqe7ezpOfvWirXtFmKjCvbWf6bl4HgojvP8Wa94V7glxV75p/8Tsj5j5FwvFJfbbhlBJDNXiQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.17.0.tgz",
+      "integrity": "sha512-GJVN1EXg2OQKXrrP1pOYDVzgph3CCe8hrC9ecOYt+Ywfxjr4GGBqHk8J0/G/geJTVXKfxDQiOKKJ64MZbyfvJQ==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "rdf-string": "^1.4.2",
-        "rdf-terms": "^1.5.1"
+        "@comunica/bus-rdf-dereference": "^1.17.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2"
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-sparql": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.16.0.tgz",
-      "integrity": "sha512-G6OCciGr/mGg6TQ4+iEnWgSqYyrKmhXQ8UzkLPS6FJXyxWJoEoiHpebYMN9Zw6XycJKnZxlqVUrmIuz3Cxde5g==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.17.0.tgz",
+      "integrity": "sha512-H/PX4Nkd6CcKKG8fkZOmLnqQAd/bwuwU+xqk2i0fFYzBsEbFP+AmaX5QjK98k05UDfHjkuyTpX7evdlN1zrKYA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.16.0",
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "rdf-terms": "^1.4.0",
-        "sparqlalgebrajs": "^2.3.2"
+        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.17.0",
+        "@comunica/bus-query-operation": "^1.17.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.17.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.16.0.tgz",
-      "integrity": "sha512-bHQLxjCtDHiUxIop8IWfReZhBPWpusPfc39A65VyQsZ7lBF/ZF21fTDaGJ8XlmiAYNBanDwjVIKe5ng3MGzwww==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.17.0.tgz",
+      "integrity": "sha512-Bvc9A4umn8BxrG9FapptPDWNJ1sktC1G2xRMKT0nQWKFT+sYwrSGS2FGMD2BMaUg94c7ipWbeWJF9GdT6ryBYA==",
       "dev": true,
       "requires": {
-        "@comunica/data-factory": "^1.14.0",
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "rdf-terms": "^1.5.1"
+        "@comunica/data-factory": "^1.17.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.16.0.tgz",
-      "integrity": "sha512-eNcn6N5Db5NyBPf4/on+baLr6pqeO86OcbfrjHkdU98MnR5CTXMF68/MCkwRLfcYooRG+o6z6EV/T/wonVeT8g==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.17.0.tgz",
+      "integrity": "sha512-LfGtzO/XAT8MoKrgq9Zjfq3FjdDqc08pmEaCTqqZdrRep2K6vM4v/E+lhY8DhbgRi07Ck6suvR1NidjA/asRIg==",
       "dev": true,
       "requires": {
-        "@comunica/utils-datasource": "^1.16.0",
-        "@rdfjs/data-model": "^1.1.1",
+        "@comunica/bus-rdf-metadata": "^1.17.0",
+        "@comunica/bus-rdf-metadata-extract": "^1.17.0",
+        "@comunica/utils-datasource": "^1.17.0",
         "@types/lru-cache": "^5.1.0",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
         "lru-cache": "^6.0.0",
-        "rdf-string": "^1.4.2",
-        "rdf-terms": "^1.5.1"
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.4.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -3679,173 +3735,176 @@
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.16.0.tgz",
-      "integrity": "sha512-+APHJ2NNegd+dtbMIRnNKksBWk4lqEE70snWBKLavxcae0oq6rq3IvZypuARQETFfxICK9KtAtwg6Z7G19QjKw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.17.0.tgz",
+      "integrity": "sha512-vn1A1bpJoiVVskRB8lnsHCllXjdeH525Lg6RoQElsZzNM0AGFnRBpo2GG/28XFnJAlYBbmo9R1I32UvKL54wqQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3"
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.16.0.tgz",
-      "integrity": "sha512-TfeEDKaYCR3NZvOmhaUY49+Z+5vPKRnx3xTA5L1GsvsU4Bc2kdFKI7ax7FR1p3CrM7AHDlxvu8/AzHIAWFbtxg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.17.0.tgz",
+      "integrity": "sha512-zGwp5StYmzqzyxoWfsTHBcZ/yeNCNZc7yJnTkiRN/RpqpEfVUXUgCi8+QwHX4XfSbuc+aH1j4LCmSZdDCxZL2Q==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "rdf-terms": "^1.4.0",
-        "sparqlalgebrajs": "^2.3.2",
-        "sparqljson-parse": "^1.5.0"
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.4.0",
+        "sparqljson-parse": "^1.6.0"
       }
     },
     "@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.15.0.tgz",
-      "integrity": "sha512-+QeLhBWY9Ce0sNW6yDm7GoEdFNlMsQ01k71yBhaBRPhe/gYEbJc0chZAUoByCY0dJRqtfZK1Wc5gjfTrG/ctdQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.17.0.tgz",
+      "integrity": "sha512-33PPtiT5VPtC9ba8podzVp8G8Dh62JIgEC+Tk3zQyVxJQIC9SJJdjzqsCW5xfyWRKP0fZ/BYEIlR22rnu/AlEw==",
       "dev": true,
       "requires": {
-        "jsonld-streaming-serializer": "^1.1.0"
+        "jsonld-streaming-serializer": "^1.2.0"
       }
     },
     "@comunica/actor-rdf-serialize-n3": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.15.0.tgz",
-      "integrity": "sha512-/9wY7o875w103A9a/SNpk65rFcp+bT3mSOnjV1bUnMVhvy73AsRG88uiwGUbS6GDFBPzA2j/l8OD+I4U3j6I7Q==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.17.0.tgz",
+      "integrity": "sha512-pA0kRA4phNWdHFtrQKuQyqjx8NJ4hWAYmnex8T7m1BwPxpIyDF7CPB+Z59e4sxUVnP97azAAfepzZcswQMZ+hQ==",
       "dev": true,
       "requires": {
-        "@types/n3": "^1.4.2",
-        "@types/rdf-js": "^3.0.0",
-        "n3": "^1.0.0",
-        "rdf-string": "^1.4.2"
+        "@types/n3": "^1.4.4",
+        "@types/rdf-js": "*",
+        "n3": "^1.6.3",
+        "rdf-string": "^1.5.0"
       }
     },
     "@comunica/actor-sparql-parse-algebra": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.16.0.tgz",
-      "integrity": "sha512-hby1X7JYxgS1T84bLYna2Cs5XCA4cCaUJMAJ8emd/IyHoW0VT4N0moCofnswjykeJ9HgCOWMbs6FqfahZS1Tag==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.17.0.tgz",
+      "integrity": "sha512-J1qBDzis5TKTwri9yaYm9KL1Fx0YL00jAzEvDFHOlPs3Lr1hn8IsG2XFA5k/Cz6XsHzpkqljz7hvIFjOke5LzA==",
       "dev": true,
       "requires": {
         "@types/sparqljs": "^3.0.0",
-        "rdf-string": "^1.4.2",
-        "sparqlalgebrajs": "^2.3.2",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0",
         "sparqljs": "^3.1.1"
       }
     },
     "@comunica/actor-sparql-parse-graphql": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.15.0.tgz",
-      "integrity": "sha512-QggTh7b/LgzZRqKR+p46hXoJiH5ge/JTbWQM92QCRa2TsNm2hGpuvCwUS0VoPiUN+O/Vbtw6IH+09qJAnEt0+w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.17.0.tgz",
+      "integrity": "sha512-4ShsChxk5/MS+hIrlK/l3Sf2m9jXJYfm0Z9kh4Xj6akzywYa+Q+yywEs7n1S1yy5f5LK2HcvlAWKhGYyrZnaww==",
       "dev": true,
       "requires": {
-        "graphql-to-sparql": "^2.1.0"
+        "graphql-to-sparql": "^2.2.0"
       }
     },
     "@comunica/actor-sparql-serialize-json": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.16.0.tgz",
-      "integrity": "sha512-9T6WlZtCOvYm37j7tgGvRCYO716naaqG4V2LbIYVcxoCxqUlfPcpE07eXt8GfWEG9R6QQuvk8UvEPqZrNiPmNQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.17.0.tgz",
+      "integrity": "sha512-vHC0PgGv+WapFXwy/WM6re81p+DB7GO0oh6NAxp4KT8fV+ZA1N6OgPSPvQYOyCFwim8vOeaKj4rGW9I7sealYQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "rdf-string": "^1.4.2"
+        "@types/rdf-js": "*",
+        "rdf-string": "^1.5.0"
       }
     },
     "@comunica/actor-sparql-serialize-rdf": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.16.0.tgz",
-      "integrity": "sha512-KBwIuwzZp5qoSFPy+8n81x2uuV8P6pzwG3r2skdir+CfIygGb0Yxf0EzCKfVDBCYn/h4lFJPwMbqXbfflwN7Ww==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.17.0.tgz",
+      "integrity": "sha512-F2sUkPXAXxVAC/H/0qV5eYlmLKD6y1RQKNRipsV2cLW4udRNad9Rn+W4BKUV/QqVUiOvck/U6ZOtHRxSdlA2rQ==",
       "dev": true
     },
     "@comunica/actor-sparql-serialize-simple": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.16.0.tgz",
-      "integrity": "sha512-Cu4MpzGlXQn/tI68fKuttny6cPmvyFBllypkZybPOtGwMY/TyA5FSd/GQLCagfP/gSm6XYnmK04D8gzY1Bwrlw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.17.0.tgz",
+      "integrity": "sha512-Ict8UeXryHJtS/5IB4RIAmTfIXUoO87xV7J+9HQBFesaLBudtZ45nlKioluby2e+TRKeWGnnYSJcs2A7vSF7Jw==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-csv": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.16.0.tgz",
-      "integrity": "sha512-unsuwwpuXdf+mqnrlFws/XpywRCPMjXccXZo2ORNlV4/iuWB3pIToAW0dnhTNxXafpWKiN/lcX05xQitH6jm3Q==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.17.0.tgz",
+      "integrity": "sha512-MKZT358ZwEReHsQJp3CTgpEjCOYJkZk+ijuWzmauyJFQV0QDuIdZMGQrzl49ScRFSDdKg8MPjXJwFgb0cs4skA==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@comunica/bus-query-operation": "^1.17.0",
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-json": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.16.0.tgz",
-      "integrity": "sha512-JVAPseFNzUT82mH9udR2QJXw0uWo6TcpHVYXk0JbvXOXwH4NBuAkXiYFBMv1ghbtpyN31Xol7Pa90mwGb8rrMw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.17.0.tgz",
+      "integrity": "sha512-YOL0RbP/VeGKZ/6CEHrhXmWw9PA0Elb3OvYMs73lW/UyZxJem1wm0YY6fQ2EoLnfIpwIEUloYrVz1MSOSUFaVw==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-tsv": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.16.0.tgz",
-      "integrity": "sha512-GX6ELMgGa3ztPZC2jKQ6/xyYf+fg4p/6p/ww/GzrSplEpmRlKFQIgUCu735ZKM3w5lZdxf8IDzOeVqDARI8jhw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.17.0.tgz",
+      "integrity": "sha512-/7XbAO+mIoWK1F69HflKhvvDey7Qg0EKzi26GZq84pgBe+qGft0Q/zg3c3wpo+ezDgfjtkpmci8CYHz7RRvz9g==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "rdf-string-ttl": "^1.0.1"
+        "@comunica/bus-query-operation": "^1.17.0",
+        "@types/rdf-js": "*",
+        "rdf-string-ttl": "^1.1.0"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-xml": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.16.0.tgz",
-      "integrity": "sha512-udTwQMSGY25S9YePdMKrWgndHrxhcFpEZ2u8msTxbZkkJZhW8qKxh4rMUE5ESGsrFPwtlYQTX+gPu2LZ+zXAnA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.17.0.tgz",
+      "integrity": "sha512-NZ1PnF4YJTihZaml/zIT/OwKTx/FDD6HUNOw7iPVgqzeGmDXItV3Ijno2yrC92bXzSa8Tsq1EXYRhapgt/9Log==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
+        "@types/rdf-js": "*",
         "@types/xml": "^1.0.2",
         "xml": "^1.0.1"
       }
     },
     "@comunica/actor-sparql-serialize-stats": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.16.0.tgz",
-      "integrity": "sha512-tGeOR5tgyP7yG7fSiPuI2Md+/ZFRJk8A6eSXGAGvZaNTGIhDmaF21jLfon/OUrJTO3jlsR1a1mZ2Hl5jshp2kA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.17.0.tgz",
+      "integrity": "sha512-O8ix5XY04ZIjzo9CRtP1Dm/XsYcgLDTHGCUGq7qXe3Bs2UX5tDDyjbNXolnlM4sniQ6GnwQSCoCGnqFXkbcQXA==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-table": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.16.0.tgz",
-      "integrity": "sha512-Sj5AJqP5fPEL8Nr2sG6K64crd7FOChPzFojSE6L750SXutQSNDuJ/Zm8N1xfZxGsxTeYNUhzr+WxzSKoWuwzQA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.17.0.tgz",
+      "integrity": "sha512-VcMtpEYiQ1BxM+gLpM6d/mREegr/mSqZzcCjkHLcjrqUbuPdtw/n/bOVzENxHVScGOgbSiQOzqv5iDV0mcukvw==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "rdf-terms": "^1.4.0"
+        "@types/rdf-js": "*",
+        "rdf-terms": "^1.6.2"
       }
     },
     "@comunica/actor-sparql-serialize-tree": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.16.0.tgz",
-      "integrity": "sha512-9BMQ8nL4Cso2NOsiKrcGQp/Ccmer8jhfJowOQhRioLI54w2+lVGXBfR8t/Mj9T4bWabtgY8AES25ZjGS2hh2gg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.17.0.tgz",
+      "integrity": "sha512-Z5Z1mlePZEBEIH58YZZT31DVnkQLhXqcV3jY+WGeboFs+SHTU6/5WU0cOq+EgwHyj0ws/tl4z5a1GKgovEpccQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
+        "@types/rdf-js": "*",
         "sparqljson-to-tree": "^2.0.0"
       }
     },
     "@comunica/bus-context-preprocess": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.15.0.tgz",
-      "integrity": "sha512-qB+DQX2YiXjc/vJ84fE9nW6XXgMDbYIwgtjn5wmfvQWjr+9p0yVjk32IMU9kRa7ETp9OytY/pHebvVHDhuHBYw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.17.0.tgz",
+      "integrity": "sha512-1iz9gP0jv6NwmVYIUnmvD9LRwI/6oljf2qSaZfUhY9ZQpUxL8BdXTYi2zICfuZajADiPO4wjevxFNO/ps0FGTg==",
       "dev": true
     },
     "@comunica/bus-http": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.16.0.tgz",
-      "integrity": "sha512-3fWJA3Yh7Wj4clabg141FgAH+m8/InZ+BVPr7BqhO+7Jg0tXbvGDfai8N0SXWL7rCMkWjlPYkBHkzpQ8Dk0HAg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.17.0.tgz",
+      "integrity": "sha512-inCpvyieVj2PuDVtX1lFAXRFuhBbgHQCDeyHedDIeg20WX2meQuCqxBvYjjLkNXqfvjFFnjJoTE5yXaZST+cbw==",
       "dev": true,
       "requires": {
         "is-stream": "^2.0.0",
@@ -3853,244 +3912,257 @@
       }
     },
     "@comunica/bus-http-invalidate": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.15.0.tgz",
-      "integrity": "sha512-RGURwbcUtD81ZYMMqs3EXB8ML35HENnGnrnrl0iO07R8HdJ/V5sczM8cxo5/+MXDpAqA9ao99AHJARwyHgoFmQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.17.0.tgz",
+      "integrity": "sha512-UfvxlXnq1QrpsB3ohtEJeubNmsd+0UUm8Ht7o7rIjWJsqn6M3uTq9/bBIDQLxbKl35ZHZE1m7ii6yip/D9CToQ==",
       "dev": true
     },
     "@comunica/bus-init": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.15.0.tgz",
-      "integrity": "sha512-HwVTEznx2H7GvcfQAREz52QF8xXT1AqxkJDnI9vTeGvLpWrM+LVOAJZxBcYFFK3X3bEhTsPfDVzikziMGqZuZw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.17.0.tgz",
+      "integrity": "sha512-Ys1db2RqkMaZuLc9pvpnUYxbE6Yvlg6Hclta/Za0NFa2nVPBj7HkTWWZhF6KcAmEYYfS4I8Oj3tGUAgytZbWUQ==",
       "dev": true
     },
     "@comunica/bus-optimize-query-operation": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.16.0.tgz",
-      "integrity": "sha512-7mvHenP7semqGlWge4EIvueK1/s4TjMpyL/RKF0Twa8Fwp0r66dFjprkAitV7K95U4FJvD0KSJPWTnQsJBdxrg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.17.0.tgz",
+      "integrity": "sha512-C7P6xvBi/T298Bnh//BcdKIUXl6mZOMZFmrdrwG7rViKr3477U5WgCeuIlT2xQhvD3KmQvVqfGlTC10dDJMA6w==",
       "dev": true,
       "requires": {
-        "sparqlalgebrajs": "^2.3.2"
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/bus-query-operation": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.16.0.tgz",
-      "integrity": "sha512-xusr0PelD5ej1B9+ff7AFDXRMidDR167Lzazaits7wNd400sG2RpIJjnEvNqU6g6d0R5WnUWCpCuv4hFQZ15sQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.17.0.tgz",
+      "integrity": "sha512-lj3yj/dQHUwbdPz0McT77m2QbtkU6hozHhHM/NFhQSFdj4b1SBQSZZAZdd6wmtrKRfvjXhR+Iy9+3w2tTmSJqw==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "immutable": "^3.8.2"
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "immutable": "^3.8.2",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/bus-rdf-dereference": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.15.0.tgz",
-      "integrity": "sha512-4vXq8e51zK1gkw5lxL2HkqYx/Wig215w8Bi3jguUTM/10EQW7KgebhRxeFU/EQOamFTMeS5anOu5BVfNps8rJQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.17.0.tgz",
+      "integrity": "sha512-OS24EHDua7YnLp+QSB0708dulOIKSuL48SNLQ1aRmP0gbEVAQz4EnV2OD+TBCgXpK4mSwHMRVTvvQvGIYIaWYA==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-dereference-paged": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.15.0.tgz",
-      "integrity": "sha512-xejwEanK8yaI/ST1SDE2Tjs9f/PsS5SvtYIVEZuWew9Ey4UlxcW/Tsz4m5YA40DeYbXaXg7m40ZeWJxwiislrw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.17.0.tgz",
+      "integrity": "sha512-lVh6psBhpLvl0PfW+JpLH5KNS3zGmVmilvfAOBMLN36dj7UcmUn/spnKjf1D4QKYuQ1N5go08y6QAOpCQl3TEQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3"
       }
     },
     "@comunica/bus-rdf-join": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.16.0.tgz",
-      "integrity": "sha512-v2RilDXPIc1sOtGnhskNqvbeyp4jOBTTUnHUEHCIdopZVUhEIj+zpZdHFoPOIbtHK6eQlQ0Ckx3E3mX84fZVyA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.17.0.tgz",
+      "integrity": "sha512-rN6hkU4YTOyi4w0+70bRbf5mUxkW20QZ+EXds+YqnqrcSgzoivyG1gFvCseMVn7gr4CszAnkWZWYBTQt311w9Q==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3"
       }
     },
     "@comunica/bus-rdf-metadata": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.15.0.tgz",
-      "integrity": "sha512-XhyMkScTBA0KUPTHtmO+kxAUyHhvuigiC6NzAoBZ9wm4y+r3aZ++mpBpAv/Fyma5GiT19EAW2pa8ew7CV9GR3A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.17.0.tgz",
+      "integrity": "sha512-kmJN8aS9YAt8M2m9KLGO4p5iA7mse/5pspnorO9fAhSn3ugu+s4q6CuA4ZaGzE2b83I2mUoxV0XVfz++6MOD2g==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-metadata-extract": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.15.0.tgz",
-      "integrity": "sha512-uxLy3hvpWuLoopoG5clYb3imhQXHGHMKHXe97jfvXA0hjoWleNtD0KRfhs+45YCBXqfNC9PVypTb9eM6SVILNQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.17.0.tgz",
+      "integrity": "sha512-jEGo4juBl8qih4lwfJCMHKeU5b88dOFjtzvwpHTybM6IlXSZ2GqNr+nxbyIDoA8c6nnNZ/hfUaZdsTYee34F9A==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "graphql-ld": "^1.1.0",
-        "rdf-store-stream": "^1.0.1"
+        "@types/rdf-js": "*",
+        "graphql-ld": "^1.2.0",
+        "rdf-store-stream": "^1.0.1",
+        "sparqlalgebrajs": "^2.4.0",
+        "stream-to-string": "^1.2.0"
       }
     },
     "@comunica/bus-rdf-parse": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.15.0.tgz",
-      "integrity": "sha512-6cGGUBgorkJ6hr5U235qSrlK1m7rPpIM8W6o9kbRAw149AKap1XFF3OXpAYqat2eB4Cbs1J2PP9wg1/s/uOsww==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.17.0.tgz",
+      "integrity": "sha512-YTXF9kQx0djyFOGs1pgmfa6I/Cis5IMEehvxLl4gBYDy/QX18ajNLykCrmi9qfydEZR8XVoyCorZiQMHsOkv8Q==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.15.0",
-        "@types/rdf-js": "^3.0.0"
+        "@comunica/actor-abstract-mediatyped": "^1.17.0",
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-parse-html": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.15.0.tgz",
-      "integrity": "sha512-7F/kDrNf9X//IrO/CK4LpwM5f+mFHLa/wsPc2RubyhiFN3P3KWU6NWxjDJRT9yP85EmW4KknXWwF8AOTvbKF1A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.17.0.tgz",
+      "integrity": "sha512-UD42SgxKevcZwKJgjdcQW8otPNo3+aJ9Sr8/litXMD+9SfxJk4bHyCp3qfM/Zmy0tObuSRu/FcWAx8XhZ+RsFA==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.15.0.tgz",
-      "integrity": "sha512-mnSsNMa2FS6x0b0K453J4c2+1UQoe2WX/p3UXfF7YocWFc7eL7JUsZO8+XZ1Pq8WaPpz+sUeaz+JtIYgVtqSGg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.17.0.tgz",
+      "integrity": "sha512-xQ2OlOY9xca+Qxx8xUGx2sRp/6rHO3w4MTaX1ol0/Mtxbzh3ocN8M1YB5yKl2Lg7NprZuEYp+GAU3QVcBMLcbQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "asyncreiterable": "^2.0.0"
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.17.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3"
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia-links": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.15.0.tgz",
-      "integrity": "sha512-AJD48ftgMdPj5x0hMTRkzNHeywsMqWnXOK7c6L2m3TlUyMtw5PWNYKd2CD1qyXE7xmSi2cKLKA5TKDkQqV7GCg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.17.0.tgz",
+      "integrity": "sha512-Sw2v9pBAqP1wd9Dr0EQ9X0V6RiBTNBd8sObmQHgg6D6h7YZ8Mk9YuPS5hv12fcub0R81NUoFxNsXTcXZ2ZamGw==",
       "dev": true
     },
     "@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.16.0.tgz",
-      "integrity": "sha512-CHZQcBFVMeUiB2DyGWzDRzvXO+s7uNS6SwnrvXVujCpdYFKfB15uG9mcpc8tZGwHDr18xq6iuLZcEKMl5wqGjA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.17.0.tgz",
+      "integrity": "sha512-36Ei6vrzXc2VWXqNbRebBrEH4g9OZ51cf1tRhQCMnXT5oZhy5+Y36cRaL9u9nQlEsgINhVVOj4/ijJ41ti+g4w==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.1",
-        "asyncreiterable": "^2.0.0"
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.0.3",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/bus-rdf-serialize": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.15.0.tgz",
-      "integrity": "sha512-c1uJF1LkJ96zscMCe+CB2fLbXhlJ0o8PPVRMm3Jk7/rc8WY5bUxSxf1SFbA/jkOZtcZy59wFHDvPf/NM74ADBg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.17.0.tgz",
+      "integrity": "sha512-NW9ZzBGrQzfo+jxiLgMPZsRf6VqDYf5B2H/G5q6acMWvm2XCDLiH9RG91khrXq8BrxNReLaSaWlvxAraHiU1xQ==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.15.0",
-        "@types/rdf-js": "^3.0.0"
+        "@comunica/actor-abstract-mediatyped": "^1.17.0",
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-sparql-parse": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.15.0.tgz",
-      "integrity": "sha512-4aFz5qnnnPxezK/vtvltqqUlN0NhYNFEQwXYZf6Yi2dSS/Hs4cU4kYcldXxIXeBfRQkaoUtTCr0lCUg5uOyqIQ==",
-      "dev": true
-    },
-    "@comunica/bus-sparql-serialize": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.16.0.tgz",
-      "integrity": "sha512-LLPheBBYBuSAweou+4kQf0Gop/lNORXOuaDfsHemLG6VqNmWzYyl79rnjd7yTLcZn/QVMUUYDD21CPY8OU5lJQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.17.0.tgz",
+      "integrity": "sha512-EirRWEvEpMN97QWQrtY1CBeMvz86iJI0l6elRslsMFzcgZk5FbKW6A8ErFQqSrcaUK7GZAqYsTtD2dqwojM5LQ==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.15.0"
+        "sparqlalgebrajs": "^2.4.0"
+      }
+    },
+    "@comunica/bus-sparql-serialize": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.17.0.tgz",
+      "integrity": "sha512-vKaxjtrYV4hQeXda2eBqkJlNpKnLs9lIVwcyeER8tSmzxXQLvrS8+wioQbm5MjpPA9UMrjsEoYp8hjvzDwBtyA==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^1.17.0"
       }
     },
     "@comunica/core": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.15.0.tgz",
-      "integrity": "sha512-Mg/fpufyK4hVKX2vgP8oapu4ZpyugNRxyI/1AX7zlhSkYpE+ldK5YQaGG/sb+fq+s2sAtE1Ocd+thCgF4wv+8w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.17.0.tgz",
+      "integrity": "sha512-fHvlXUVF70CQ8xZCwOr8AXjGY3zzSAojJ8j3n+qxG5HzisdyPsUAKzCeG/UBZcqhGmuddV/8hYyvxy9KNv9tEg==",
       "dev": true,
       "requires": {
         "immutable": "^3.8.2"
       }
     },
     "@comunica/data-factory": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-1.14.0.tgz",
-      "integrity": "sha512-zpTpglsFIHuklarPCFTG2nRRG+RD1biT9nscggltShKJRK2EAtpnMeABGS/QU6es5CC96ZdA94KlVmFxt51A+g==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-1.17.0.tgz",
+      "integrity": "sha512-AjU4kpIWq5Rx7MN/uGlmrAHCvPri2I6GMc+zUL7URMlj8veOk1R9w7ol5Z3mtpB65NhYQJtB4D9riff30b6/lw==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/logger-pretty": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.15.0.tgz",
-      "integrity": "sha512-Ta0u/YHHgSvX9Au8JqzhgqmNiPLwFW2L1ZLnUR3V0J+uQDL2PEayWnw+xrDyVKgYJaffevJYHowjn4c4D5DxFA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.17.0.tgz",
+      "integrity": "sha512-F3K2p1/+yM4H0Hv0i1P673qqjeo07cg3JOlHa2+4L55CeioH3+lgDzrpwzH5pocm7c8SaBEbKxDZdXSoayi11g==",
       "dev": true
     },
     "@comunica/logger-void": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.15.0.tgz",
-      "integrity": "sha512-nU0bJ56hOAURnz4uDNbeldAJ88OduRQMtHEeKTSkR+ATArP/ShXFWLgKcxRnU9ELSsA7k9HlvAFpvag5+eNs8g==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.17.0.tgz",
+      "integrity": "sha512-9KppX+epg3+HA5vd83fCNUsrOVaazplAevHw6zrMwzJ05Pn5ATlPFKjrzWg5q0OOM4yYJQa8NMPv/SwLLfp1UQ==",
       "dev": true
     },
     "@comunica/mediator-all": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.15.0.tgz",
-      "integrity": "sha512-uALhqOxGIT/gBXWkIVE+PTITf5EIDNL2UD9GRffdgc1Qg74prWcMZ4+gYczBOMUhqZHE605QsXXO8NkT4xP14A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.17.0.tgz",
+      "integrity": "sha512-DMpfnpb5BgmzB4uCJv1JGDeYSJued2Ek4/OwXSKFjSdSLRfBl8ZtvrWdA9FdeCrRKbxin1z5V/pT7s616zjMqw==",
       "dev": true
     },
     "@comunica/mediator-combine-pipeline": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.15.0.tgz",
-      "integrity": "sha512-XYf+rOSF1Tj5JX8geHUt5O8BJmLqyRXXYZQe2nlwGoe66hshMKpzAu38m5uDpARrJ4dPxU0PrH34x1Wug77lpg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.17.0.tgz",
+      "integrity": "sha512-3OmXe3zWriLa6CyxI5sligfePGgMy0aXjbOjfBDuY/2iLd+2DUReIH2h/xICvFh4DgPp/0m/DrVOLYVaqCuZYA==",
       "dev": true
     },
     "@comunica/mediator-combine-union": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.15.0.tgz",
-      "integrity": "sha512-TPzfXuKRVBEpjb+/S8v2C8uvgi8BTjtg1htL/qY/xI2fYqRcLZGl+D5MZEESmwpmm19cBfg87CbF+ROn6L3+IQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.17.0.tgz",
+      "integrity": "sha512-BGfBKXu41G/0dlUJeNw9cJcWTJK6G2ks2X9pKvCzh+6neUrIe2sb+3aPz8ZOF4LPUFarELTk6ZuhIAQVIcxoRw==",
       "dev": true
     },
     "@comunica/mediator-number": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.15.0.tgz",
-      "integrity": "sha512-d1jwHVN6rELFzEPb+CDqEjItAJ4/AqiP1Vp+Z/PBucLjM9EEonQMjQzqrkRV/Oy6cBXfSQDhXuSvftfl/zUCjg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.17.0.tgz",
+      "integrity": "sha512-DlYO4XkjDUVfGk6aDjsK2FhyWr+6Sp2OZV7ImyaNXSDE4U/gnWz0p0SYqg8ehB/B960h3XgdaIwvKSuAEm/baw==",
       "dev": true
     },
     "@comunica/mediator-race": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.15.0.tgz",
-      "integrity": "sha512-MVESJnkgSoPaCkNNN8RDm0B06d0JNL4QOvRZFuFETY4/D+OwIpcEf0EGButQsDUlelAk5n/sFssLMqo2tw65SA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.17.0.tgz",
+      "integrity": "sha512-oYKT00VB/0eZdhjJuZRWKmmhamFQfYUIeGWnqeM9z2Zz97HPh6fZBcus5wxjzjvxaXHv4XLvwbrxi7ohXmy1nA==",
+      "dev": true
+    },
+    "@comunica/mediatortype-iterations": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-iterations/-/mediatortype-iterations-1.17.0.tgz",
+      "integrity": "sha512-WU+cUlvPtYtYigy2gfMaqGk+BHIgHnJuW6easOLCINHc1jS/dtOEQGqd7zOZrwbSSFx+675DmshrVI+uGPh+kA==",
       "dev": true
     },
     "@comunica/runner": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.16.0.tgz",
-      "integrity": "sha512-ZQuTt10UpcUbiXu94MSFCgaYkraCtgXewEbXus5Jf0OUbSqa/fkxwWs4wTxak/9CjtFLMb4GO3jfoYoeWbqtfA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.17.0.tgz",
+      "integrity": "sha512-aPe5F4w8+xMRwMfqyxAXso/OqRMxoB4tblBfacPk+C3MssNJDluXaqwUZYwiiu5UOV6nUwneCYFIGbLv6XkZZw==",
       "dev": true,
       "requires": {
         "componentsjs": "^3.4.1"
       }
     },
     "@comunica/runner-cli": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.16.0.tgz",
-      "integrity": "sha512-9XfRqACWeppe/po/UMIN4MH+gU/8YszRqyPG02vd9k0AnPXYMK5AXPj4ge3D0HQE+ENb2y9C5xe516w0yl8eBw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.17.0.tgz",
+      "integrity": "sha512-rNMhY2ZPPQKQIEDi2/So9w/7++hXXyBwBODhDsvF01mpuX3xxBbNUnk0VR3/DufyeDu93PquzPEmAArWrgLCyg==",
       "dev": true,
       "requires": {
-        "@comunica/runner": "^1.16.0"
+        "@comunica/runner": "^1.17.0"
       }
     },
     "@comunica/utils-datasource": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.16.0.tgz",
-      "integrity": "sha512-MWng1lz62YT5VLvwFvBNc119U6aNvX7oL8j7YdgRyLulB14gYEp5njuqRjbz1WFa1TtDUJxYGMPyskSMdzGilw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.17.0.tgz",
+      "integrity": "sha512-0jPvi9KH66RZWr8wz6CuiZP6exKPh3vOR9kksQsJlesBAx2vVQ1NgVFFwt4FwKTYgaO9ssjOkdTN9uJQsoYcbg==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.16.0",
-        "arrayify-stream": "^1.0.0",
-        "asynciterator": "^3.0.1",
-        "asyncreiterable": "^2.0.0"
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.17.0",
+        "asynciterator": "^3.0.3"
       }
     },
     "@emmetio/extract-abbreviation": {
@@ -4192,9 +4264,9 @@
       "dev": true
     },
     "@open-wc/building-rollup": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@open-wc/building-rollup/-/building-rollup-1.8.0.tgz",
-      "integrity": "sha512-DuaBtbMlb8llBp3K0hVACbq7My/jc9PeGsfIxx/qwE2uzkTcYkedHi62rhKFWG2gLvcSPdFDxzZt/klhRWlxIQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/building-rollup/-/building-rollup-1.9.1.tgz",
+      "integrity": "sha512-CxOb44Wk5hleqUtHYeFcj1KtAr58gGAOOXIwTf7coU+5wLlQqJrhmxHNm/J2pXUIykgK/TqN5xNOKvxy1ztqBg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.1",
@@ -4207,9 +4279,9 @@
         "@babel/plugin-transform-modules-systemjs": "^7.10.5",
         "@babel/plugin-transform-runtime": "^7.11.0",
         "@babel/preset-env": "^7.9.0",
-        "@open-wc/building-utils": "^2.18.1",
-        "@open-wc/rollup-plugin-html": "^1.2.3",
-        "@open-wc/rollup-plugin-polyfills-loader": "^1.1.4",
+        "@open-wc/building-utils": "^2.18.2",
+        "@open-wc/rollup-plugin-html": "^1.2.4",
+        "@open-wc/rollup-plugin-polyfills-loader": "^1.1.5",
         "@rollup/plugin-babel": "^5.1.0",
         "@rollup/plugin-node-resolve": "^7.1.1",
         "babel-plugin-bundled-import-meta": "^0.3.2",
@@ -4219,15 +4291,15 @@
         "magic-string": "^0.25.7",
         "parse5": "^5.1.1",
         "regenerator-runtime": "^0.13.3",
-        "rollup-plugin-terser": "^5.2.0",
+        "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-workbox": "^5.0.1",
         "terser": "^4.6.7"
       }
     },
     "@open-wc/building-utils": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.18.1.tgz",
-      "integrity": "sha512-FBSlR94BwrVlHcaWSESzlYOVLqrUKnC8L88yHajCm/cONaEWYhP/O7SXVHgLnXkjYbCgCGMKbq6fuSnwf5jElQ==",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.18.2.tgz",
+      "integrity": "sha512-oE9cG9X4zpqm9OnQ2s+aaK7pAa8v3wt0YJBhZT3RisoKp/Va4kmsNBTjW2LPkHVK5N0VvPYukS3ey8S53e9ssQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.1",
@@ -4242,7 +4314,7 @@
         "core-js-bundle": "^3.6.0",
         "deepmerge": "^4.2.2",
         "es-module-shims": "^0.4.6",
-        "html-minifier": "^4.0.0",
+        "html-minifier-terser": "^5.1.1",
         "lru-cache": "^5.1.1",
         "minimatch": "^3.0.4",
         "parse5": "^5.1.1",
@@ -4282,36 +4354,35 @@
       "integrity": "sha512-UfdK1MPnR6T7f3svzzYBfu3qBkkZ/KsPhcpc3JYhsUY4hbpwNF9wEQtD4Z+/mRqMTJrKg++YSxIxE0FBhY3RIw=="
     },
     "@open-wc/karma-esm": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-3.0.5.tgz",
-      "integrity": "sha512-T4bSjEPAizT4TLcULLg4/DT/gLvddeUTX3zgdON8Cns0mSy/HdWy/rWfdEbG65u6343PmZZ102h+tQhC7l+YGA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-3.0.6.tgz",
+      "integrity": "sha512-Mn2sW0qGcij3dR9o50h5VCLZFTmxwa33MIn5pAWOonkplsWb0nyUwDgKsxkycaTc0hnOLna2kFbRamWv4+oIJg==",
       "dev": true,
       "requires": {
-        "@open-wc/building-utils": "^2.18.1",
+        "@open-wc/building-utils": "^2.18.2",
         "babel-plugin-istanbul": "^5.1.4",
         "chokidar": "^3.0.0",
         "deepmerge": "^4.2.2",
-        "es-dev-server": "^1.57.4",
+        "es-dev-server": "^1.57.5",
         "minimatch": "^3.0.4",
         "node-fetch": "^2.6.0",
-        "polyfills-loader": "^1.7.1",
+        "polyfills-loader": "^1.7.2",
         "portfinder": "^1.0.21",
         "request": "^2.88.0"
       }
     },
     "@open-wc/rollup-plugin-html": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-html/-/rollup-plugin-html-1.2.3.tgz",
-      "integrity": "sha512-0Xd90QrOHTN8OIlAK+RWdp2SiscRpwWHpootLHVoyz3nUZPy6sjE5W6gGlZHe2Zc59iBs7ai+CecH2RlaqrX2A==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-html/-/rollup-plugin-html-1.2.4.tgz",
+      "integrity": "sha512-YhFHFVuIf8RpBWVhrVRaR9JSJssjlAr9muVKAs2Nvvg4hpSP3chE9OB4AXRbGOgno7cdVeeUKbPev12RWty0kg==",
       "dev": true,
       "requires": {
-        "@open-wc/building-utils": "^2.18.1",
+        "@open-wc/building-utils": "^2.18.2",
         "@types/html-minifier": "^3.5.3",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
-        "html-minifier": "^4.0.0",
-        "parse5": "^5.1.1",
-        "terser": "^4.6.7"
+        "html-minifier-terser": "^5.1.1",
+        "parse5": "^5.1.1"
       },
       "dependencies": {
         "fs-extra": {
@@ -4328,13 +4399,13 @@
       }
     },
     "@open-wc/rollup-plugin-polyfills-loader": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-polyfills-loader/-/rollup-plugin-polyfills-loader-1.1.4.tgz",
-      "integrity": "sha512-jNUdsmVgSwiRriEzbaeiR8CB3YDyw0Vljt/35A4iluMyNst8S1S0v7aDi0aa6h0MzmC7JRAP6EEpJ2QfjzmY5A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-polyfills-loader/-/rollup-plugin-polyfills-loader-1.1.5.tgz",
+      "integrity": "sha512-10+mMaNrDVJD1Vc7Wmu4IgUxJQ3f99LzMi6h/fGUvVeqnm1/yOAUV3DXaUmAfjw87OwAAZGJSqla+++zURv52A==",
       "dev": true,
       "requires": {
-        "@open-wc/rollup-plugin-html": "^1.2.3",
-        "polyfills-loader": "^1.7.1"
+        "@open-wc/rollup-plugin-html": "^1.2.4",
+        "polyfills-loader": "^1.7.2"
       }
     },
     "@open-wc/scoped-elements": {
@@ -4348,29 +4419,29 @@
       }
     },
     "@open-wc/semantic-dom-diff": {
-      "version": "0.17.10",
-      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.17.10.tgz",
-      "integrity": "sha512-7RAJqHsaFGA8LoBlgaScTxSu5FXga89Af1RXv3n/Rmv/x/W5mmyIKMfUR3F/RJofm2/FwnLWtaHgwS9qB1eNfg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.18.0.tgz",
+      "integrity": "sha512-TyW5WwzcKemtoAY+mennsUoy+at+Tw6deO15eTaV6k5IeIpEqPz/0K8QWcXcawpExWVBzmJ+H1rMJLhENj9iUw==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.2.11"
       }
     },
     "@open-wc/testing": {
-      "version": "2.5.25",
-      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-2.5.25.tgz",
-      "integrity": "sha512-j+i3YDLDmarb2ZRy/NdRY/y2PyEB48rrMUJrOg1/yxmgAp9xACVeQROBFL1h7I3HgyaG84KPXhJ8T6GRXUR7Qg==",
+      "version": "2.5.27",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-2.5.27.tgz",
+      "integrity": "sha512-Bwabn0C+yL5dOT2A7d4vltvQ4wdLKWxBIXrNp9XSVfuWYX72cfcAVM29K35+uQjcqsQI8/AveBa/y6Q83o2nEw==",
       "dev": true,
       "requires": {
         "@open-wc/chai-dom-equals": "^0.12.36",
-        "@open-wc/semantic-dom-diff": "^0.17.10",
+        "@open-wc/semantic-dom-diff": "^0.18.0",
         "@open-wc/testing-helpers": "^1.8.9",
         "@types/chai": "^4.2.11",
         "@types/chai-dom": "^0.0.9",
         "@types/mocha": "^5.0.0",
         "@types/sinon-chai": "^3.2.3",
         "chai": "^4.2.0",
-        "chai-a11y-axe": "^1.3.0",
+        "chai-a11y-axe": "^1.3.1",
         "chai-dom": "^1.8.1",
         "mocha": "^6.2.2",
         "sinon-chai": "^3.3.0"
@@ -4427,6 +4498,12 @@
             "portfinder": "^1.0.21",
             "request": "^2.88.0"
           }
+        },
+        "axe-core": {
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+          "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+          "dev": true
         },
         "base64id": {
           "version": "1.0.0",
@@ -4844,15 +4921,6 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
-    "@polymer/iron-iconset-svg": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz",
-      "integrity": "sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==",
-      "requires": {
-        "@polymer/iron-meta": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
     "@polymer/iron-media-query": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-media-query/-/iron-media-query-3.0.1.tgz",
@@ -4980,30 +5048,10 @@
         "prismjs": "^1.11.0"
       }
     },
-    "@rdfjs/data-model": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.2.tgz",
-      "integrity": "sha512-pk/G/JLYGaXesoBLvEmoC/ic0H3B79fTyS0Ujjh5YQB2DZW+mn05ZowFFv88rjB9jf7c1XE5XSmf8jzn6U0HHA==",
-      "dev": true,
-      "requires": {
-        "@types/rdf-js": "^2.0.1"
-      },
-      "dependencies": {
-        "@types/rdf-js": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.12.tgz",
-          "integrity": "sha512-NBzHFHp2vHOJkPlSqzsOrkEsD9grKn+PdFjZieIw59pc0FlRG6WEQAjQZvHzFxJlYzC6ZDCFyTA1wBvUnnzUQw==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        }
-      }
-    },
     "@rollup/plugin-babel": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.0.tgz",
-      "integrity": "sha512-CPABsajaKjINgBQ3it+yMnfVO3ibsrMBxRzbUOUw2cL1hsZJ7aogU8mgglQm3S2hHJgjnAmxPz0Rq7DVdmHsTw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.1.tgz",
+      "integrity": "sha512-Jd7oqFR2dzZJ3NWANDyBjwTtX/lYbZpVcmkHrfQcpvawHs9E4c0nYk5U2mfZ6I/DZcIvy506KZJi54XK/jxH7A==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
@@ -5148,9 +5196,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
-      "integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+      "version": "7.1.10",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
+      "integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -5161,18 +5209,18 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-      "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__template": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-      "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
+      "integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -5180,9 +5228,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
-      "integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
+      "integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -5214,9 +5262,9 @@
       "dev": true
     },
     "@types/browserslist-useragent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/browserslist-useragent/-/browserslist-useragent-3.0.0.tgz",
-      "integrity": "sha512-ZBvKzg3yyWNYEkwxAzdmUzp27sFvw+1m080/+2lwrt+eltNefn1f4fnpMyrjOla31p8zLleCYqQXw+3EETfn0w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/browserslist-useragent/-/browserslist-useragent-3.0.1.tgz",
+      "integrity": "sha512-EI/mKugA9lVyR8TXSZv0TygeUOpFOP7MKBgJ99JJZKBKVfLH3kHB9alT0s5KgYHup1c1jw6N+XQHlXyWspKmNw==",
       "dev": true
     },
     "@types/cacheable-request": {
@@ -5376,9 +5424,9 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.7.tgz",
-      "integrity": "sha512-dCOT5lcmV/uC2J9k0rPafATeeyz+99xTt54ReX11/LObZgfzJqZNcW27zGhYyX+9iSEGXGt5qLPwRSvBZcLvtQ==",
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
+      "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -5388,9 +5436,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.9",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz",
-      "integrity": "sha512-DG0BYg6yO+ePW+XoDENYz8zhNGC3jDDEpComMYn7WJc4mY1Us8Rw9ax2YhJXxpyk2SF47PQAoQ0YyVT1a0bEkA==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
+      "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -5457,12 +5505,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
-      "dev": true
-    },
-    "@types/isomorphic-fetch": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz",
-      "integrity": "sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==",
       "dev": true
     },
     "@types/json5": {
@@ -5585,18 +5627,18 @@
       }
     },
     "@types/koa__cors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.0.1.tgz",
-      "integrity": "sha512-loqZNXliley8kncc4wrX9KMqLGN6YfiaO3a3VFX+yVkkXJwOrZU4lipdudNjw5mFyC+5hd7h9075hQWcVVpeOg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.0.2.tgz",
+      "integrity": "sha512-gBetQR0DJ9JTG1YQoW33BADHCrDPJGiJUKUUcEPJwW1A2unzpIMhorEpXB6eMaaXTaqHLemcGnq3RmH9XaryRQ==",
       "dev": true,
       "requires": {
         "@types/koa": "*"
       }
     },
     "@types/lodash": {
-      "version": "4.14.160",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.160.tgz",
-      "integrity": "sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA==",
+      "version": "4.14.161",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
+      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
       "dev": true
     },
     "@types/lru-cache": {
@@ -5640,9 +5682,9 @@
       }
     },
     "@types/node": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.1.tgz",
-      "integrity": "sha512-HnYlg/BRF8uC1FyKRFZwRaCPTPYKa+6I8QiUZFLredaGOou481cgFS4wKRFyKvQtX8xudqkSdBczJHIYSQYKrQ==",
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -5679,9 +5721,9 @@
       "dev": true
     },
     "@types/puppeteer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-3.0.1.tgz",
-      "integrity": "sha512-t03eNKCvWJXhQ8wkc5C6GYuSqMEdKLOX0GLMGtks25YZr38wKZlKTwGM/BoAPVtdysX7Bb9tdwrDS1+NrW3RRA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-3.0.2.tgz",
+      "integrity": "sha512-JRuHPSbHZBadOxxFwpyZPeRlpPTTeMbQneMdpFd8LXdyNfFSiX950CGewdm69g/ipzEAXAmMyFF1WOWJOL/nKw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -5694,9 +5736,9 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==",
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
       "dev": true
     },
     "@types/range-parser": {
@@ -5706,9 +5748,9 @@
       "dev": true
     },
     "@types/rdf-js": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-3.0.3.tgz",
-      "integrity": "sha512-1dvodNHh/YpLovHA/b046Nu+xERVt0KcYJFQH1A8S4ZcMj+stYtx4ypXw0X2/oatbREUo4JW+cjoBll3CVtwSQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.0.tgz",
+      "integrity": "sha512-2uaR7ks0380MqzUWGOPOOk9yZIr/6MOaCcaj3ntKgd2PqNocgi8j5kSHIJTDe+5ABtTHqKMSE0v0UqrsT8ibgQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -5749,18 +5791,18 @@
       }
     },
     "@types/sinon": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.5.tgz",
-      "integrity": "sha512-4CnkGdM/5/FXDGqL32JQ1ttVrGvhOoesLLF7VnTh4KdjK5N5VQOtxaylFqqTjnHx55MnD9O02Nbk5c1ELC8wlQ==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.6.tgz",
+      "integrity": "sha512-j3GK0fiHgn8fe7sqOpInMjm0A2Tary1NBZ8gbI/sZ0C0JxYeO+nh8H0/pW/0l94vNWcH1FnZOZu/cOvIfNZTrg==",
       "dev": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
       }
     },
     "@types/sinon-chai": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.4.tgz",
-      "integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.5.tgz",
+      "integrity": "sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==",
       "dev": true,
       "requires": {
         "@types/chai": "*",
@@ -5768,15 +5810,15 @@
       }
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
-      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
       "dev": true
     },
     "@types/sparqljs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.0.1.tgz",
-      "integrity": "sha512-2SGl+Q4Gq0Rh/y0ZT6iBvQDDlws3NiPKfkMaEnGDWHvwNonlSZt03jm7HJ7C9I+huwBQ5l5SOYpeJsrh0nOJew==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.0.tgz",
+      "integrity": "sha512-Tb+WnG8xLb2XHI3Nub4b6WFWT5gPgGrwhNS9u+jX1uTCBylPMnKSwCcr2UJF2yEZ2Jw8EaNBy27hhmGwhMXccw==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
@@ -5840,20 +5882,20 @@
       }
     },
     "@wdio/config": {
-      "version": "6.1.14",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.1.14.tgz",
-      "integrity": "sha512-MXHMHwtkAblfnIxONs9aW//T9Fq5XIw3oH+tztcBRvNTTAIXmwHd+4sOjAwjpCdBSGs0C4kM/aTpGfwDZVURvQ==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.4.7.tgz",
+      "integrity": "sha512-wtcj9yKm5+SivwhsgpusBrFR7a3rpDsN/WH6ekoqlZFs7oCpJeTLwawWnoX6MJQy2no5o00lGxDDJnqjaBdiiQ==",
       "dev": true,
       "requires": {
-        "@wdio/logger": "6.0.16",
+        "@wdio/logger": "6.4.7",
         "deepmerge": "^4.0.0",
         "glob": "^7.1.2"
       }
     },
     "@wdio/logger": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.0.16.tgz",
-      "integrity": "sha512-VbH5UnQIG/3sSMV+Y38+rOdwyK9mVA9vuL7iOngoTafHwUjL1MObfN/Cex84L4mGxIgfxCu6GV48iUmSuQ7sqA==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.4.7.tgz",
+      "integrity": "sha512-Mm/rsRa/1u/l8/IrNKM2c9tkvLE90i83d3KZ0Ujh4cicYJv+lNi9whsCi+p3QNFCo64nJ6bfC+0Ho5VgD3MiKw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -5930,21 +5972,21 @@
       "dev": true
     },
     "@wdio/repl": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.4.0.tgz",
-      "integrity": "sha512-3oSRBzbWM67kng/ZqcDtFTHhTVO/fIALNqfyEEzaMb7oJ2OXgibBzjEa1r8ZhKIC8TpEAJ29BdSll4brHUhQrw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.5.0.tgz",
+      "integrity": "sha512-qKm2j0qY7mrZQipHv4PhKpAL7pkyxCzW1XDoEjp09OHLvmGvvCwY6aEBuLziD9BaiR30BXVNLIKPZfM4Xl2Zfg==",
       "dev": true,
       "requires": {
-        "@wdio/utils": "6.4.0"
+        "@wdio/utils": "6.5.0"
       }
     },
     "@wdio/utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.4.0.tgz",
-      "integrity": "sha512-sAVBbgQjUmvbvkQ/EyWIUSDoebtiZewmf6wb6Pt6EZfaTm4hul30Txd+IXfazhuxp701PskwufkMWzrQIXhpKw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.5.0.tgz",
+      "integrity": "sha512-k5RxRj/re/BbK76SjWSmyhJFHWnXD74vl/doCAQNuOaKFBd2dqMCs3GiFjYCyLcU37XGMAnRvI3tKHflyLGJYw==",
       "dev": true,
       "requires": {
-        "@wdio/logger": "6.0.16"
+        "@wdio/logger": "6.4.7"
       }
     },
     "@webcomponents/shadycss": {
@@ -5996,9 +6038,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
     "after": {
@@ -6032,9 +6074,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -6050,9 +6092,9 @@
       "dev": true
     },
     "amf-client-js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.3.0.tgz",
-      "integrity": "sha512-fLRM3evsYnJOkJ5hRJO954/UvfcMbjm1YrEla/zTl6FY5RpTjYG4/YBSnBGnfOxZA5jPaKSG02RLPBQd2o910g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.3.1.tgz",
+      "integrity": "sha512-jbHPJ4LhORXdrYkD9P5Ns48W9J1MVFyG93moxSnMVcW+OhVjTRQ88unstPr2s1ueI5mYRsxlD+AUvCBGojIHFw==",
       "dev": true,
       "requires": {
         "ajv": "6.5.2",
@@ -6197,9 +6239,9 @@
       }
     },
     "archiver": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.0.tgz",
-      "integrity": "sha512-AEWhJz6Yi6hWtN1Sqy/H4sZo/lLMJ/NftXxGaDy/TnOMmmjsRaZc/Ts+U4BsPoBQkuunTN6t8hk7iU9A+HBxLw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.2.tgz",
+      "integrity": "sha512-Tq3yV/T4wxBsD2Wign8W9VQKhaUxzzRmjEiSoOK0SLqPgDP/N1TKdYyBeIEu56T4I9iO4fKTTR0mN9NWkBA0sg==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
@@ -6207,7 +6249,7 @@
         "buffer-crc32": "^0.2.1",
         "readable-stream": "^3.6.0",
         "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.1.2",
+        "tar-stream": "^2.1.4",
         "zip-stream": "^4.0.0"
       },
       "dependencies": {
@@ -6240,12 +6282,12 @@
           }
         },
         "tar-stream": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-          "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+          "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
           "dev": true,
           "requires": {
-            "bl": "^4.0.1",
+            "bl": "^4.0.3",
             "end-of-stream": "^1.4.1",
             "fs-constants": "^1.0.0",
             "inherits": "^2.0.3",
@@ -6432,9 +6474,9 @@
       "dev": true
     },
     "asynciterator": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.0.1.tgz",
-      "integrity": "sha512-i63IZ/CLbSwT+9+jezA8BFnMmmOylNN+2/yNqMSr37IdzjPLnYMfEvTOFt46hDA+san7k9CZN6gEzCgCTTfAWA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.0.3.tgz",
+      "integrity": "sha512-mNvEwsk6DN7+co9T2be/Eor0kKQGIXCoGg27v7vsCLlFdSXlboH06UGCy9cfEh2qAfDdgsEpmDn6y59f3+ZvgA==",
       "dev": true
     },
     "asyncjoin": {
@@ -6451,15 +6493,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "asyncreiterable": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/asyncreiterable/-/asyncreiterable-2.0.0.tgz",
-      "integrity": "sha512-Pq9wUkHrXshCxXWy4/O7krS9qGCgHxoDWajWJja/7f5KoZTcO5Xww25NSMTek+jL3CZ4GrHYvOHx5bmrR4nU3w==",
-      "dev": true,
-      "requires": {
-        "asynciterator": "^3.0.0"
-      }
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -6486,9 +6519,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.2.tgz",
+      "integrity": "sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==",
       "dev": true
     },
     "babel-eslint": {
@@ -6903,9 +6936,9 @@
       "dev": true
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.3.5",
@@ -7022,15 +7055,15 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.0.tgz",
-      "integrity": "sha512-pUsXKAF2lVwhmtpeA3LJrZ76jXuusrNyhduuQs7CDFf9foT4Y38aQOserd2lMe5DSSrjf3fx34oHwryuvxAUgQ==",
+      "version": "4.14.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
+      "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001111",
-        "electron-to-chromium": "^1.3.523",
-        "escalade": "^3.0.2",
-        "node-releases": "^1.1.60"
+        "caniuse-lite": "^1.0.30001135",
+        "electron-to-chromium": "^1.3.571",
+        "escalade": "^3.1.0",
+        "node-releases": "^1.1.61"
       }
     },
     "browserslist-useragent": {
@@ -7097,9 +7130,9 @@
       "dev": true
     },
     "buffer-indexof-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
-      "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
       "dev": true
     },
     "buffers": {
@@ -7263,13 +7296,13 @@
       "dev": true
     },
     "camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "pascal-case": "^3.1.1",
+        "tslib": "^1.10.0"
       }
     },
     "camelcase": {
@@ -7318,9 +7351,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001119",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001119.tgz",
-      "integrity": "sha512-Hpwa4obv7EGP+TjkCh/wVvbtNJewxmtg4yVJBLFnxo35vbPapBr138bUWENkb5j5L9JZJ9RXLn4OrXRG/cecPQ==",
+      "version": "1.0.30001137",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz",
+      "integrity": "sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw==",
       "dev": true
     },
     "canonicalize": {
@@ -7338,27 +7371,6 @@
         "no-case": "^3.0.3",
         "tslib": "^1.10.0",
         "upper-case-first": "^2.0.1"
-      },
-      "dependencies": {
-        "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-          "dev": true,
-          "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
-          }
-        }
       }
     },
     "caseless": {
@@ -7394,12 +7406,12 @@
       }
     },
     "chai-a11y-axe": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/chai-a11y-axe/-/chai-a11y-axe-1.3.0.tgz",
-      "integrity": "sha512-VN0keXMQvkKYC8lDNUiOEXLmKPp1cAddrRrjcdpSL2RIQVWAj1E9EOF3t4CEb2avc9FsoWehUSDAOjtiH0BbsQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/chai-a11y-axe/-/chai-a11y-axe-1.3.1.tgz",
+      "integrity": "sha512-O+JJ+fELEvK/5SwFe9ltIk+qYz9p+zjnw/iUC1qNrlpgEPvTxScvyvQSU7eP73ixxHkCH1oNFAqkiM+MopbCEw==",
       "dev": true,
       "requires": {
-        "axe-core": "^3.5.3"
+        "axe-core": "^4.0.2"
       }
     },
     "chai-dom": {
@@ -7445,47 +7457,6 @@
         "sentence-case": "^3.0.3",
         "snake-case": "^3.0.3",
         "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "camel-case": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
-          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
-          "dev": true,
-          "requires": {
-            "pascal-case": "^3.1.1",
-            "tslib": "^1.10.0"
-          }
-        },
-        "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-          "dev": true,
-          "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
-          }
-        },
-        "param-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
-          "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
-          "dev": true,
-          "requires": {
-            "dot-case": "^3.0.3",
-            "tslib": "^1.10.0"
-          }
-        }
       }
     },
     "character-entities": {
@@ -7773,9 +7744,9 @@
       }
     },
     "codemirror": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.57.0.tgz",
-      "integrity": "sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg=="
+      "version": "5.58.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.1.tgz",
+      "integrity": "sha512-UGb/ueu20U4xqWk8hZB3xIfV2/SFqnSLYONiM3wTMDqko0bsYrsAkGGhqUzbRkYm89aBKPyHtuNEbVWF9FTFzw=="
     },
     "collapse-white-space": {
       "version": "1.0.6",
@@ -7902,9 +7873,9 @@
       }
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
     },
     "common-tags": {
@@ -7948,9 +7919,9 @@
       "dev": true
     },
     "componentsjs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-3.4.2.tgz",
-      "integrity": "sha512-ICaSvvxY/CvWwFt0lLsoRL/DHY09akoI6x9WakQQ9g4GYHVaZumWSAdOrzM/htjGpBumpVh1C/4hk0/ghh9jXA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-3.6.0.tgz",
+      "integrity": "sha512-G3lMrIbE7iiZpERoPXnxM0aDopq9q1s1C5aIUrnHW3rcRDa3kcCytc4ASt5aFRjNiwBubivcMfJsvF2ihXg7jQ==",
       "dev": true,
       "requires": {
         "@types/lodash": "^4.14.56",
@@ -8105,36 +8076,6 @@
         "no-case": "^3.0.3",
         "tslib": "^1.10.0",
         "upper-case": "^2.0.1"
-      },
-      "dependencies": {
-        "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-          "dev": true,
-          "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
-          }
-        },
-        "upper-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz",
-          "integrity": "sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        }
       }
     },
     "contains-path": {
@@ -8243,9 +8184,9 @@
           "dev": true
         },
         "meow": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.0.tgz",
-          "integrity": "sha512-kq5F0KVteskZ3JdfyQFivJEj2RaA8NFsS4+r9DaMKLcUHpk5OcHS3Q0XkCXONB1mZRPsu/Y/qImKri0nwSEZog==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+          "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
           "dev": true,
           "requires": {
             "@types/minimist": "^1.2.0",
@@ -8611,12 +8552,12 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
-      "integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
       "dev": true,
       "requires": {
-        "node-fetch": "2.6.0"
+        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -8774,9 +8715,9 @@
           },
           "dependencies": {
             "domelementtype": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-              "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+              "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
               "dev": true
             }
           }
@@ -9010,12 +8951,12 @@
       "dev": true
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -9344,15 +9285,15 @@
       "dev": true
     },
     "devtools": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/devtools/-/devtools-6.4.4.tgz",
-      "integrity": "sha512-L9kfK/wkHWzBy0gvFmMmLyLzDgGbeVKk8bRwTZ3N99uo+Pt3IF6oBDjEPzE721dNzaO91/xVr5l97+Uo1eabMA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/devtools/-/devtools-6.5.0.tgz",
+      "integrity": "sha512-P/9+jSK+Jq4gWO5a79OLtDsZPcrNZN9JDCqWdCmKcbCCikV3fYic+0wmRzAPff8iYLCdmNXf/no4XMLwXR5LXQ==",
       "dev": true,
       "requires": {
-        "@wdio/config": "6.1.14",
-        "@wdio/logger": "6.0.16",
+        "@wdio/config": "6.4.7",
+        "@wdio/logger": "6.4.7",
         "@wdio/protocols": "6.3.6",
-        "@wdio/utils": "6.4.0",
+        "@wdio/utils": "6.5.0",
         "chrome-launcher": "^0.13.1",
         "puppeteer-core": "^5.1.0",
         "ua-parser-js": "^0.7.21",
@@ -9360,9 +9301,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.781568",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.781568.tgz",
-      "integrity": "sha512-9Uqnzy6m6zEStluH9iyJ3iHyaQziFnMnLeC8vK0eN6smiJmIx7+yB64d67C2lH/LZra+5cGscJAJsNXO+MdPMg==",
+      "version": "0.0.799653",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.799653.tgz",
+      "integrity": "sha512-t1CcaZbvm8pOlikqrsIM9GOa7Ipp07+4h/q9u0JXBWjPCjHdBl9KkddX87Vv9vBHoBGtwV79sYQNGnQM6iS5gg==",
       "dev": true
     },
     "di": {
@@ -9461,9 +9402,9 @@
       }
     },
     "dom-serializer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.0.1.tgz",
-      "integrity": "sha512-1Aj1Qy3YLbdslkI75QEOfdp9TkQ3o8LRISAzxOibjBs/xWwr1WxZFOQphFkZuepHFGo+kB8e5FVJSS0faAJ4Rw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.1.0.tgz",
+      "integrity": "sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
@@ -9491,34 +9432,34 @@
       }
     },
     "domelementtype": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-      "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+      "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
       "dev": true
     },
     "domhandler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
-      "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.2.0.tgz",
+      "integrity": "sha512-FnT5pxGpykNI10uuwyqae65Ysw7XBQJKDjDjlHgE/rsNtjr1FyGNVNQCVlM5hwcq9wkyWSqB+L5Z+Qa4khwLuA==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1"
       }
     },
     "dompurify": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.14.tgz",
-      "integrity": "sha512-oqcjyCLHLjWugZ6VwK0YfmRND/DFy/CuZhdasmymMfnxbzaaQxBSA1ATZIXWESGDj/nvq1vKLmRa7rTdbGgrmQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.1.1.tgz",
+      "integrity": "sha512-NijiNVkS/OL8mdQL1hUbCD6uty/cgFpmNiuFxrmJ5YPH2cXrPKIewoixoji56rbZ6XBPmtM8GA8/sf9unlSuwg=="
     },
     "domutils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.2.0.tgz",
-      "integrity": "sha512-0haAxVr1PR0SqYwCH7mxMpHZUwjih9oPPedqpR/KufsnxPyZ9dyVw1R5093qnJF3WXSbjBkdzRWLw/knJV/fAg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.1.tgz",
+      "integrity": "sha512-AA5r2GD1Dljhxc+k4zD2HYQaDkDPBhTqmqF55wLNlxfhFQlqaYME8Jhmo2nKNBb+CNfPXE8SAjtF6SsZ0cza/w==",
       "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0"
+        "domhandler": "^3.2.0"
       }
     },
     "dot-case": {
@@ -9529,27 +9470,6 @@
       "requires": {
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-          "dev": true,
-          "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
-          }
-        }
       }
     },
     "dot-prop": {
@@ -9673,9 +9593,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.554",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.554.tgz",
-      "integrity": "sha512-Vtz2dVH5nMtKK4brahmgScwFS8PBnpA4VObYXtlsqN8ZpT9IFelv0Rpflc1+NIILjGVaj6vEiXQbhrs3Pl8O7g==",
+      "version": "1.3.574",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.574.tgz",
+      "integrity": "sha512-kF8Bfe1h8X1pPwlw6oRoIXj0DevowviP6fl0wcljm+nZjy/7+Fos4THo1N/7dVGEJlyEqK9C8qNnbheH+Eazfw==",
       "dev": true
     },
     "emoji-regex": {
@@ -9695,26 +9615,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -9737,6 +9637,17 @@
         "debug": "~4.1.0",
         "engine.io-parser": "~2.2.0",
         "ws": "^7.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "engine.io-client": {
@@ -9763,6 +9674,15 @@
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
           "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
         },
         "ws": {
           "version": "6.1.4",
@@ -9846,9 +9766,9 @@
       }
     },
     "es-dev-server": {
-      "version": "1.57.4",
-      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.57.4.tgz",
-      "integrity": "sha512-GNstq4VeNmkon9W4dABCC3e3540cWVmhsnO4d8axBSgk0D4HQH/t2NqM4o9Qvq4/z9NMAqW1CazmvuFdl8oqKg==",
+      "version": "1.57.5",
+      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.57.5.tgz",
+      "integrity": "sha512-QILo/BBXDLR7mARKrCfqr3xx8MkNF9YB3JGUufOJIEUIat9i2SFVktWD1Al4xqBofxKoqh0t7BY/xn6MzdXJAQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.1",
@@ -9863,7 +9783,7 @@
         "@babel/plugin-transform-template-literals": "^7.8.3",
         "@babel/preset-env": "^7.9.0",
         "@koa/cors": "^3.1.0",
-        "@open-wc/building-utils": "^2.18.1",
+        "@open-wc/building-utils": "^2.18.2",
         "@rollup/plugin-node-resolve": "^7.1.1",
         "@rollup/pluginutils": "^3.0.0",
         "@types/babel__core": "^7.1.3",
@@ -9907,7 +9827,7 @@
         "open": "^7.0.3",
         "parse5": "^5.1.1",
         "path-is-inside": "^1.0.2",
-        "polyfills-loader": "^1.7.1",
+        "polyfills-loader": "^1.7.2",
         "portfinder": "^1.0.21",
         "rollup": "^2.7.2",
         "strip-ansi": "^5.2.0",
@@ -9941,9 +9861,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.24.tgz",
-      "integrity": "sha512-jm/i7KdJtaMDle921xIsA/MQQOGuZ6goYxhlV+k+gQNI7FtP4N6jknrmJvj++3ODpiyFGwQ4PIstJfHJQJNc+g==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.25.tgz",
+      "integrity": "sha512-H9VoFD5H9zEfiOX2LeTWDwMvAbLqcAyA2PIb40TOAvGpScOjit02oTGWgIh+M0rx2eJOKyJVM9wtpKFVgnyC3A==",
       "dev": true
     },
     "es-module-shims": {
@@ -9976,9 +9896,9 @@
       "dev": true
     },
     "escalade": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
-      "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
       "dev": true
     },
     "escape-html": {
@@ -10113,9 +10033,9 @@
       "dev": true
     },
     "eslint-config-prettier": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
-      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz",
+      "integrity": "sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -10176,18 +10096,18 @@
       }
     },
     "eslint-plugin-html": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-6.0.3.tgz",
-      "integrity": "sha512-1KV2ebQHywlXkfpXOGjxuEyoq+g6AWvD6g9TB28KsGhbM5rJeHXAEpHOev6LqZv6ylcfa9BWokDsNVKyYefzGw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-6.1.0.tgz",
+      "integrity": "sha512-xcqithhnjUxoEDRL0hYci4RSS8EZ1NGr3/H8x3BxJvxgbu4R3YaEUea9i93j95NuAgoAbOUfNmybta8fqi4UbA==",
       "dev": true,
       "requires": {
         "htmlparser2": "^4.1.0"
       }
     },
     "eslint-plugin-import": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
-      "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
@@ -10195,7 +10115,7 @@
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.3",
+        "eslint-import-resolver-node": "^0.3.4",
         "eslint-module-utils": "^2.6.0",
         "has": "^1.0.3",
         "minimatch": "^3.0.4",
@@ -10243,12 +10163,12 @@
       }
     },
     "eslint-scope": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
@@ -10308,12 +10228,20 @@
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "estraverse": {
@@ -10862,19 +10790,19 @@
       }
     },
     "fetch-sparql-endpoint": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-1.6.2.tgz",
-      "integrity": "sha512-d0nTwXc6BBnQdrmx7+Bk6pLJ5MLzJtYJRNq4YSpL4Bym8hd12RaBUL7OkcxtuFaMY9gG2Mw0JVNMZeF3bjVSBg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-1.7.0.tgz",
+      "integrity": "sha512-9sikkrE0byU0ASQBswOnRsVA/vs3mWGkLGEwC/8fIYqhgR0Hbe663cDvuNjFxJxh60cQd6E7NvCWoSpKOBCckg==",
       "dev": true,
       "requires": {
+        "cross-fetch": "^3.0.6",
         "is-stream": "^2.0.0",
-        "isomorphic-fetch": "^2.2.1",
         "minimist": "^1.2.0",
-        "n3": "^1.0.0",
-        "rdf-string": "^1.3.1",
-        "sparqljs": "^3.0.0",
-        "sparqljson-parse": "^1.5.0",
-        "sparqlxml-parse": "^1.2.0",
+        "n3": "^1.6.3",
+        "rdf-string": "^1.5.0",
+        "sparqljs": "^3.1.2",
+        "sparqljson-parse": "^1.6.0",
+        "sparqlxml-parse": "^1.4.0",
         "stream-to-string": "^1.1.0",
         "web-streams-node": "^0.4.0"
       }
@@ -11327,9 +11255,9 @@
           "dev": true
         },
         "meow": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.0.tgz",
-          "integrity": "sha512-kq5F0KVteskZ3JdfyQFivJEj2RaA8NFsS4+r9DaMKLcUHpk5OcHS3Q0XkCXONB1mZRPsu/Y/qImKri0nwSEZog==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+          "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
           "dev": true,
           "requires": {
             "@types/minimist": "^1.2.0",
@@ -11615,19 +11543,19 @@
       }
     },
     "got": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.5.2.tgz",
-      "integrity": "sha512-yUhpEDLeuGiGJjRSzEq3kvt4zJtAcjKmhIiwNp/eUs75tRlXfWcHo5tcBaMQtnjHWC7nQYT5HkY/l0QOQTkVww==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.7.0.tgz",
+      "integrity": "sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^3.0.0",
+        "@sindresorhus/is": "^3.1.1",
         "@szmarczak/http-timer": "^4.0.5",
         "@types/cacheable-request": "^6.0.1",
         "@types/responselike": "^1.0.0",
         "cacheable-lookup": "^5.0.3",
         "cacheable-request": "^7.0.1",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
         "p-cancelable": "^2.0.0",
         "responselike": "^2.0.0"
@@ -11676,9 +11604,9 @@
           "dev": true
         },
         "keyv": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
-          "integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+          "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
           "dev": true,
           "requires": {
             "json-buffer": "3.0.1"
@@ -11738,41 +11666,30 @@
       "dev": true
     },
     "graphql-ld": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/graphql-ld/-/graphql-ld-1.1.0.tgz",
-      "integrity": "sha512-nYfXYhpJMuWLTJ1q4fu64Y59OYVR2xQCJcPMEgzYEDEArUIyyEOi8l+VeL/ttBZVg47RICiiC3e26qRYwBR+kQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-ld/-/graphql-ld-1.2.0.tgz",
+      "integrity": "sha512-CEYmJcFCW7EumwOFdTVqo5cEv53VJLll5rNWQ29YOWLM6HKLzuWB+TBf40I4Eub+xai1Q7oFD9xguhq/rg9oaw==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^2.0.11",
-        "graphql-to-sparql": "^2.1.0",
-        "jsonld-context-parser": "^2.0.0",
-        "sparqlalgebrajs": "^2.2.1",
-        "sparqljson-to-tree": "^2.0.0"
-      },
-      "dependencies": {
-        "@types/rdf-js": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.12.tgz",
-          "integrity": "sha512-NBzHFHp2vHOJkPlSqzsOrkEsD9grKn+PdFjZieIw59pc0FlRG6WEQAjQZvHzFxJlYzC6ZDCFyTA1wBvUnnzUQw==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        }
+        "@types/rdf-js": "*",
+        "graphql-to-sparql": "^2.2.0",
+        "jsonld-context-parser": "^2.1.0",
+        "sparqlalgebrajs": "^2.4.0",
+        "sparqljson-to-tree": "^2.1.0"
       }
     },
     "graphql-to-sparql": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-2.1.1.tgz",
-      "integrity": "sha512-o+bnwrL4ugil/A4a+x/C8Yae+irxm3xLQGXWrjc5p9K2KEiforY4bU8Ed6Q/wasFjeublCp2v0xEFDnUxyY40g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-2.2.0.tgz",
+      "integrity": "sha512-RHe8mpmYtUreOLhvjbgwJKNGwQsvDyMdHNj+x4REgX7V02QSZvbpHE2IG6c0TO1DjbLRNUK7/2pRUhfq8FDLeA==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/rdf-js": "^3.0.0",
+        "@types/rdf-js": "*",
         "graphql": "^15.0.0",
-        "jsonld-context-parser": "^2.0.0",
+        "jsonld-context-parser": "^2.0.2",
         "minimist": "^1.2.0",
-        "sparqlalgebrajs": "^2.0.0"
+        "rdf-data-factory": "^1.0.3",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "growl": {
@@ -12037,21 +11954,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "html-minifier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
-      "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
-      "dev": true,
-      "requires": {
-        "camel-case": "^3.0.0",
-        "clean-css": "^4.2.1",
-        "commander": "^2.19.0",
-        "he": "^1.2.0",
-        "param-case": "^2.1.1",
-        "relateurl": "^0.2.7",
-        "uglify-js": "^3.5.1"
-      }
-    },
     "html-minifier-terser": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
@@ -12065,34 +11967,6 @@
         "param-case": "^3.0.3",
         "relateurl": "^0.2.7",
         "terser": "^4.6.3"
-      },
-      "dependencies": {
-        "camel-case": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
-          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
-          "dev": true,
-          "requires": {
-            "pascal-case": "^3.1.1",
-            "tslib": "^1.10.0"
-          }
-        },
-        "commander": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-          "dev": true
-        },
-        "param-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
-          "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
-          "dev": true,
-          "requires": {
-            "dot-case": "^3.0.3",
-            "tslib": "^1.10.0"
-          }
-        }
       }
     },
     "htmlparser2": {
@@ -12214,15 +12088,15 @@
       "dev": true
     },
     "husky": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-4.2.5.tgz",
-      "integrity": "sha512-SYZ95AjKcX7goYVZtVZF2i6XiZcHknw50iXvY7b0MiGoj5RwdgRQNEHdb+gPDPCXKlzwrybjFjkL6FOj8uRhZQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.0.tgz",
+      "integrity": "sha512-tTMeLCLqSBqnflBZnlVDhpaIMucSGaYyX6855jM4AguGeWCeSzNdb1mfyWduTZ3pe3SJVvVWGL0jO1iKZVPfTA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
         "compare-versions": "^3.6.0",
-        "cosmiconfig": "^6.0.0",
+        "cosmiconfig": "^7.0.0",
         "find-versions": "^3.2.0",
         "opencollective-postinstall": "^2.0.2",
         "pkg-dir": "^4.2.0",
@@ -12267,16 +12141,16 @@
           "dev": true
         },
         "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
           "dev": true,
           "requires": {
             "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
+            "import-fresh": "^3.2.1",
             "parse-json": "^5.0.0",
             "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
+            "yaml": "^1.10.0"
           }
         },
         "find-up": {
@@ -12688,9 +12562,9 @@
       }
     },
     "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
     },
     "is-color-stop": {
@@ -12825,6 +12699,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
+      "dev": true
+    },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
       "dev": true
     },
     "is-number": {
@@ -12994,34 +12874,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -13241,22 +13093,29 @@
       }
     },
     "jest-worker": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-      "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+      "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
       "dev": true,
       "requires": {
+        "@types/node": "*",
         "merge-stream": "^2.0.0",
-        "supports-color": "^6.1.0"
+        "supports-color": "^7.0.0"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -13308,9 +13167,9 @@
       "dev": true
     },
     "json-parse-even-better-errors": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz",
-      "integrity": "sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "json-schema": {
@@ -13374,62 +13233,50 @@
       }
     },
     "jsonld-context-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.0.2.tgz",
-      "integrity": "sha512-IjQi26E+5ESS85MkcLsYo9gV93oJSOvQ/deHxKspaeHOmRiPyRRaGAk86DjuQc6c0hdp3OKGvDDsy3wi8znsqg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.1.tgz",
+      "integrity": "sha512-7yKhnwFaiCnDPUZYQuAWyT0zZBfOKZDyjtqFVNbXrYRkboU+m55UsastsfXbo7qNroTGdFiEyxHEHDEfBC0P4Q==",
       "dev": true,
       "requires": {
         "@types/http-link-header": "^1.0.1",
-        "@types/isomorphic-fetch": "^0.0.35",
         "@types/node": "^13.1.0",
         "canonicalize": "^1.0.1",
+        "cross-fetch": "^3.0.6",
         "http-link-header": "^1.0.2",
-        "isomorphic-fetch": "^2.2.1",
         "relative-to-absolute-iri": "^1.0.5"
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
-          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+          "version": "13.13.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz",
+          "integrity": "sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ==",
           "dev": true
         }
       }
     },
     "jsonld-streaming-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.0.2.tgz",
-      "integrity": "sha512-h4cK+PQMvOHd+UqgAFpKBmt5LWYoQMQLu9PP7YsRP7rnSJbU/EfJFcJFG6/sdtZslQ6dlNwOvfHbjQ9clzZPzg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.1.0.tgz",
+      "integrity": "sha512-9Ks9Zb7eEK+3D9WAb5RPvjUJ57FD+/KG1F0HHszjJQtl7eyQKyujLWypblD66dmedjor+zdEjIF/oj+sqqn/Dw==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.2",
         "@types/http-link-header": "^1.0.1",
-        "@types/rdf-js": "^3.0.0",
+        "@types/rdf-js": "*",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
         "jsonld-context-parser": "^2.0.1",
-        "jsonparse": "^1.3.1"
+        "jsonparse": "^1.3.1",
+        "rdf-data-factory": "^1.0.2"
       }
     },
     "jsonld-streaming-serializer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-1.1.0.tgz",
-      "integrity": "sha512-C+cs913C3XDScZIqUL8fg5crHQtPTQSZstzvFmhA9/r0QBCRw88BR4TYHvLNhJhzB45GOpoF5/Fx4I4xfKGpOQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-1.2.0.tgz",
+      "integrity": "sha512-66uJz15dxuUFiVKbji5eV4h+1F3XTKnOhZjK9Plx0zyL1CkG5/zhCK4U1wPTg0nUhSUODZ+jAtuRoD4zdZjKYA==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^2.0.1",
+        "@types/rdf-js": "*",
         "jsonld-context-parser": "^2.0.0"
-      },
-      "dependencies": {
-        "@types/rdf-js": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.12.tgz",
-          "integrity": "sha512-NBzHFHp2vHOJkPlSqzsOrkEsD9grKn+PdFjZieIw59pc0FlRG6WEQAjQZvHzFxJlYzC6ZDCFyTA1wBvUnnzUQw==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        }
       }
     },
     "jsonlint": {
@@ -13448,9 +13295,9 @@
       "dev": true
     },
     "jsonschema": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.6.tgz",
-      "integrity": "sha512-SqhURKZG07JyKKeo/ir24QnS4/BV7a6gQy93bUSe4lUdNp0QNpIz2c9elWJQ9dpc5cQYY6cvCzgRwy0MQCLyqA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.7.tgz",
+      "integrity": "sha512-3dFMg9hmI9LdHag/BRIhMefCfbq1hicvYMy8YhZQorAdzOzWz7NjniSpn39yjpzUAMIWtGyyZuH2KNBloH7ZLw==",
       "dev": true
     },
     "jsprim": {
@@ -13471,30 +13318,29 @@
       "integrity": "sha512-u45jAyusqUpyGbFc2IbHoeE4rSkoBWQgLe/w99temHenX+GyCz4nflU5sjK7ajU1ffZTezl6le7u43Yjr/lkQg=="
     },
     "just-extend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
     },
     "karma": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-5.1.1.tgz",
-      "integrity": "sha512-xAlOr5PMqUbiKXSv5PCniHWV3aiwj6wIZ0gUVcwpTCPVQm/qH2WAMFWxtnpM6KJqhkRWrIpovR4Rb0rn8GtJzQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-5.2.3.tgz",
+      "integrity": "sha512-tHdyFADhVVPBorIKCX8A37iLHxc6RBRphkSoQ+MLKdAtFn1k97tD8WUGi1KlEtDZKL3hui0qhsY9HXUfSNDYPQ==",
       "dev": true,
       "requires": {
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
-        "chokidar": "^3.0.0",
+        "chokidar": "^3.4.2",
         "colors": "^1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",
-        "flatted": "^2.0.2",
         "glob": "^7.1.6",
         "graceful-fs": "^4.2.4",
         "http-proxy": "^1.18.1",
         "isbinaryfile": "^4.0.6",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.19",
         "log4js": "^6.2.1",
         "mime": "^2.4.5",
         "minimatch": "^3.0.4",
@@ -13504,7 +13350,7 @@
         "socket.io": "^2.3.0",
         "source-map": "^0.6.1",
         "tmp": "0.2.1",
-        "ua-parser-js": "0.7.21",
+        "ua-parser-js": "0.7.22",
         "yargs": "^15.3.1"
       },
       "dependencies": {
@@ -13956,9 +13802,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "10.2.13",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.2.13.tgz",
-      "integrity": "sha512-conwlukNV6aL9SiMWjFtDp5exeDnTMekdNPDZsKGnpfQuHcO0E3L3Bbf58lcR+M7vk6LpCilxDAVks/DDVBYlA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.4.0.tgz",
+      "integrity": "sha512-uaiX4U5yERUSiIEQc329vhCTDDwUcSvKdRLsNomkYLRzijk3v8V9GWm2Nz0RMVB87VcuzLvtgy6OsjoH++QHIg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -14150,9 +13996,9 @@
       "dev": true
     },
     "listr2": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-2.6.1.tgz",
-      "integrity": "sha512-1aPX9GkS+W0aHfPUDedJqeqj0DOe1605NaNoqdwEYw/UF2UbZgCIIMpXXZALeG/8xzwMBztguzQEubU5Xw1Qbw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-2.6.2.tgz",
+      "integrity": "sha512-6x6pKEMs8DSIpA/tixiYY2m/GcbgMplMVmhQAaLFxEtNSKLeWTGjtmU57xvv6QCm2XcqzyNXL/cTSVf4IChCRA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -14548,10 +14394,13 @@
       }
     },
     "lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.10.0"
+      }
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -15079,6 +14928,18 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
+        "object.assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+          "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        },
         "p-limit": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -15219,9 +15080,9 @@
       }
     },
     "n3": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.2.tgz",
-      "integrity": "sha512-9R45WRNxNPblKLbXGwR9IvtaVvdr80vRxME79fhWnqBzHb2GcP6lS77Mvf8Fx6Wpfn8PpBTdggceWsSMDGY/SA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.3.tgz",
+      "integrity": "sha512-dN+8pLw2h1H1WQTW9VR3T16tHPDYdQP+YKXzbcpBCMCb9ZkksUyoVRRdtFGl3vosdET+NIB5eiIgth+4Vit6Yw==",
       "dev": true,
       "requires": {
         "queue-microtask": "^1.1.2",
@@ -15321,12 +15182,13 @@
       }
     },
     "no-case": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "^2.0.1",
+        "tslib": "^1.10.0"
       }
     },
     "node-cache": {
@@ -15357,15 +15219,15 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.60",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
-      "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+      "version": "1.1.61",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
+      "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
       "dev": true
     },
     "nomnom": {
@@ -15532,15 +15394,37 @@
       }
     },
     "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -15761,12 +15645,13 @@
       "dev": true
     },
     "param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+      "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "dot-case": "^3.0.3",
+        "tslib": "^1.10.0"
       }
     },
     "parent-module": {
@@ -15854,27 +15739,6 @@
       "requires": {
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-          "dev": true,
-          "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
-          }
-        }
       }
     },
     "pascalcase": {
@@ -16014,20 +15878,19 @@
       }
     },
     "polyfills-loader": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.7.1.tgz",
-      "integrity": "sha512-+cClGOZNQtWVedt2a2Ku9r6ejfnhQFbuaSPtlaGLl2R9ESWaJNoq8r29d0BTpAgrEX/xXsoh2YHgamNugW6Ahw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.7.2.tgz",
+      "integrity": "sha512-MUo8OXTDOVcGOf+WbgLiolS9cJquLQWHh3lAQKCaOxGv8Z43IJmJqmwGa6r/wfOnF4aH3f3WwHXfZAi/JjiAgg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.1",
-        "@open-wc/building-utils": "^2.18.1",
+        "@open-wc/building-utils": "^2.18.2",
         "@webcomponents/webcomponentsjs": "^2.4.0",
         "abortcontroller-polyfill": "^1.4.0",
         "core-js-bundle": "^3.6.0",
         "deepmerge": "^4.2.2",
         "dynamic-import-polyfill": "^0.1.1",
         "es-module-shims": "^0.4.6",
-        "html-minifier": "^4.0.0",
         "intersection-observer": "^0.7.0",
         "parse5": "^5.1.1",
         "regenerator-runtime": "^0.13.3",
@@ -16206,9 +16069,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+      "version": "7.0.34",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.34.tgz",
+      "integrity": "sha512-H/7V2VeNScX9KE83GDrDZNiGT1m2H+UTnlinIzhjlLX9hfMUn1mHNnGeX81a1c8JSBdBvqk7c2ZOG6ZPn5itGw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -16265,9 +16128,9 @@
       }
     },
     "postcss-calc": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.3.tgz",
-      "integrity": "sha512-IB/EAEmZhIMEIhG7Ov4x+l47UaXOS1n2f4FBUk/aKllQhtSCxWhTzn0nJgkqN7fo/jcWySvWTSB6Syk9L+31bA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.4.tgz",
+      "integrity": "sha512-0I79VRAd1UTkaHzY9w83P39YGO/M3bG7/tNLrHGEunBolfoGM0hSjrGvjoeaj0JE/zIw5GsI2KZ0UwDJqv5hjw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.27",
@@ -16351,9 +16214,9 @@
       }
     },
     "postcss-load-config": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
-      "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.2.tgz",
+      "integrity": "sha512-/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==",
       "dev": true,
       "requires": {
         "cosmiconfig": "^5.0.0",
@@ -16421,9 +16284,9 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+          "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
           "dev": true,
           "requires": {
             "is-obj": "^2.0.0"
@@ -16521,9 +16384,9 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+          "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
           "dev": true,
           "requires": {
             "is-obj": "^2.0.0"
@@ -16977,14 +16840,15 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-      "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+      "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
         "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "uniq": "^1.0.1",
+        "util-deprecate": "^1.0.2"
       }
     },
     "postcss-svgo": {
@@ -17043,9 +16907,9 @@
       "dev": true
     },
     "pretty-bytes": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
+      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
       "dev": true
     },
     "prismjs": {
@@ -17131,16 +16995,15 @@
       "dev": true
     },
     "puppeteer-core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.2.1.tgz",
-      "integrity": "sha512-gLjEOrzwgcnwRH+sm4hS1TBqe2/DN248nRb2hYB7+lZ9kCuLuACNvuzlXILlPAznU3Ob+mEvVEBDcLuFa0zq3g==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.3.1.tgz",
+      "integrity": "sha512-YE6c6FvHAFKQUyNTqFs78SgGmpcqOPhhmVfEVNYB4abv7bV2V+B3r72T3e7vlJkEeTloy4x9bQLrGbHHoKSg1w==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.781568",
+        "devtools-protocol": "0.0.799653",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
-        "mime": "^2.0.3",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
@@ -17320,43 +17183,43 @@
       }
     },
     "rdf-data-factory": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.0.0.tgz",
-      "integrity": "sha512-C+UBVeXchaywznF8VnmkRSanUpB3/f2iBrdqw2aPFqKlUgcRGHhAIQZ/AjfbM7u1beyNlEq2us3kvVIum6+uBg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.0.3.tgz",
+      "integrity": "sha512-Fm0E5JiGZl4vRK2qlMmmI/CEZeN/NgEWHyBmTmtFCyp/tAfb5veDfdB1ZqNRqR16pNHzDiPeKZmE7qCK3IehWA==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "rdf-literal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.1.1.tgz",
-      "integrity": "sha512-zYelIUgvwifeq2aFfTYlv+SoxZbSjdKw+I4ulZ5ECil8FTh2+ufHiR9P7T61KnVyo8BqBhyeHBR4UvA++PWozA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.2.0.tgz",
+      "integrity": "sha512-N7nyfp/xzoiUuJt0xZ80BvBGkCPwWejgVDkCxWDSuooXKSows4ToW+KouYkMHLcoFzGg1Rlw2lk6btjMJg5aSA==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*",
+        "rdf-data-factory": "^1.0.1"
       }
     },
     "rdf-quad": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.4.0.tgz",
-      "integrity": "sha512-xChDvhK2zb4/aCg8P668CWTn4TEhscefg/E1s+Qu61sZ/hKct/WQn0wuHim8H+MFrzZ7fFN7Gh7aamPgm/QSwA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.5.0.tgz",
+      "integrity": "sha512-LnCYx8XbRVW1wr6UiZPSy2Tv7bXAtEwuyck/68dANhFu8VMnGS+QfUNP3b9YI6p4Bfd/fyDx5E3x81IxGV6BzA==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "rdf-literal": "^1.0.0",
-        "rdf-string": "^1.3.1"
+        "rdf-data-factory": "^1.0.1",
+        "rdf-literal": "^1.2.0",
+        "rdf-string": "^1.5.0"
       }
     },
     "rdf-store-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-1.0.1.tgz",
-      "integrity": "sha512-/aMMY3UeC1ONxnDoPgpeaZPT7coqeYRFQ1U30nuJ66f6OMDBag/iYtgu871hqobgKDZEmxg9Ut3USsZzvEry0Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-1.1.0.tgz",
+      "integrity": "sha512-JWvQUv/1yja1TiEzhS1PTactSER9ORjM/6TV8z3KdGWpeQOs9TeUgLzx5PLXSRePFZ8GKNTkG5dD+wC6Yh3sbQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^3.0.2",
-        "n3": "^1.1.1"
+        "@types/rdf-js": "*",
+        "n3": "^1.6.3"
       }
     },
     "rdf-string": {
@@ -17369,43 +17232,44 @@
       }
     },
     "rdf-string-ttl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-1.0.1.tgz",
-      "integrity": "sha512-QdOztnXuQTS5HwS2YTUkY9KUdyjyMYCX4QITfAAAtJnGqQkfah1L+VdV3E+Z3NKp/CBXLqZs/oMZe5J7pUEzpw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-1.1.0.tgz",
+      "integrity": "sha512-c+CYNhrOhYF3sRuyBuwxSPRdyBDJOm6mX3FhIKrvPsAKmYE8uVtXuBoAiORc/UW7zYoM+CKmqtgkiFsqOz+6Jg==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1"
+        "rdf-data-factory": "^1.0.2"
       }
     },
     "rdf-terms": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.5.1.tgz",
-      "integrity": "sha512-dDhpUYxTAOWKT3Ln93A5k5UB5SftG8bPAzeZEjGeP4e7eboMhITUTDks8HDmUt9X1P+HpfnY/o6VSTSpf3Advw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.6.2.tgz",
+      "integrity": "sha512-dASpdYHYLEwzN9iSymJie1WUj6VHXy1By8Am4g2rJlhTfVvNitsJpDY+A3X2QehlGhCaWjHMzXS4q/JKNPI80A==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "lodash.uniqwith": "^4.5.0"
+        "lodash.uniqwith": "^4.5.0",
+        "rdf-data-factory": "^1.0.1"
       }
     },
     "rdfa-streaming-parser": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-1.2.2.tgz",
-      "integrity": "sha512-OKNyZworn+wuHd9DsskyiBor85nQPAMzSR/xm6np1Pe09edj3yRGJQLsY62Ww1ELjZbdEFXougIShhR9VwU83A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-1.3.0.tgz",
+      "integrity": "sha512-4pM+PB5jbx3h1d751dlr7u/As5fDJSQzoR5O3OGF4lQb4M6P2+RucnXQhSN9dWtI7M3EKsnZHVq9fxAvOoiDdg==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/rdf-js": "^3.0.0",
+        "@types/rdf-js": "*",
         "htmlparser2": "^4.0.0",
+        "rdf-data-factory": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.2"
       }
     },
     "rdfxml-streaming-parser": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.3.6.tgz",
-      "integrity": "sha512-t9uqmCiPjmMFMXQ3Va2rc4ePElhze63EUmXVLA05s40NQEvphj8I8Kl1qODBwHnxocdoc1yVQRsC6hVJAPHvPQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.4.0.tgz",
+      "integrity": "sha512-/FKDCq4tuSWz8PZaaPxqIQpenEvRR3Gsqllqg4VmdPFN6WiWfbaD244cKASfXfQHt9Bw7tLsLHsmtA1isIPBCg==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.2",
+        "@types/rdf-js": "*",
+        "rdf-data-factory": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.0",
         "sax": "^1.2.4"
       }
@@ -17453,9 +17317,9 @@
       "dev": true
     },
     "readdir-glob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.0.0.tgz",
-      "integrity": "sha512-km0DIcwQVZ1ZUhXhMWpF74/Wm5aFEd5/jDiVWF1Hkw2myPQovG8vCQ8+FQO2KXE9npQQvCnAMZhhWuUee4WcCQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.0.tgz",
+      "integrity": "sha512-KgT0oXPIDQRRRYFf+06AUaodICTep2Q5635BORLzTEzp7rEqcR14a47j3Vzm3ix7FeI1lp8mYyG7r8lTB06Pyg==",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
@@ -17533,9 +17397,9 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-      "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+      "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
@@ -17881,12 +17745,12 @@
       }
     },
     "roarr": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.3.tgz",
-      "integrity": "sha512-AEjYvmAhlyxOeB9OqPUzQCo3kuAkNfuDk/HqWbZdFsqDFpapkTjiw+p4svNEoRLvuqNTxqfL+s+gtD4eDgZ+CA==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "dev": true,
       "requires": {
-        "boolean": "^3.0.0",
+        "boolean": "^3.0.1",
         "detect-node": "^2.0.4",
         "globalthis": "^1.0.1",
         "json-stringify-safe": "^5.0.1",
@@ -17903,9 +17767,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.7",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.7.tgz",
-      "integrity": "sha512-3/aXJ+ibw2fqj6KBX4ioYcx8s3kseYXzyxLR6Xmm7Zakzd7WNvn9XDUahBCQ/oPVHmVO9gEeIYKHgFaZWqsJzg==",
+      "version": "2.28.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
+      "integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
@@ -17956,9 +17820,9 @@
       }
     },
     "rollup-plugin-postcss": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-3.1.6.tgz",
-      "integrity": "sha512-lkKMTXhPyaNgELFFf7mAGLqFTr13Lswak1YkP+b9rfl6YNVHxs3PYgZFAGLOyLvOtSuCVRq6BryXs1EgyC+nHQ==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-3.1.8.tgz",
+      "integrity": "sha512-JHnGfW8quNc6ePxEkZ05HEZ1YiRxDgY9RKEetMfsrwxR2kh/d90OVScTc6b1c2Q17Cs/5TRYL+1uddG21lQe3w==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -18036,16 +17900,40 @@
       }
     },
     "rollup-plugin-terser": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-      "integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "jest-worker": "^24.9.0",
-        "rollup-pluginutils": "^2.8.2",
-        "serialize-javascript": "^2.1.2",
-        "terser": "^4.6.2"
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "terser": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.3.tgz",
+          "integrity": "sha512-vRQDIlD+2Pg8YMwVK9kMM3yGylG95EIwzBai1Bw7Ot4OBfn3VP1TZn3EWx4ep2jERN/AmnVaTiGuelZSN7ds/A==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.7.2",
+            "source-map-support": "~0.5.19"
+          }
+        }
       }
     },
     "rollup-plugin-workbox": {
@@ -18085,23 +17973,6 @@
             "@types/node": "*"
           }
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-worker": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-          "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^7.0.0"
-          }
-        },
         "rollup-plugin-terser": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-6.1.0.tgz",
@@ -18121,15 +17992,6 @@
           "dev": true,
           "requires": {
             "randombytes": "^2.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         }
       }
@@ -18158,9 +18020,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-      "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -18194,9 +18056,9 @@
       "dev": true
     },
     "saucelabs": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.4.4.tgz",
-      "integrity": "sha512-RKem5TFBuGrQqUF4uhhVON+zXJSz8jOAzK4PTdwNRtgV30CayyvOOQnp2eC0KOnICnOEQgieaV9NUM6UH1PhuQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.5.0.tgz",
+      "integrity": "sha512-xPMYLLOJMnWRunZKiu92h4cKCR/SCTYBIvAHTlHYtDA09oebnwEOf7cjrv/+R0TuXgSYO85pll0mOXDIKUTB3Q==",
       "dev": true,
       "requires": {
         "bin-wrapper": "^4.1.0",
@@ -18261,6 +18123,14 @@
       "dev": true,
       "requires": {
         "commander": "^2.8.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        }
       }
     },
     "select": {
@@ -18378,27 +18248,6 @@
         "no-case": "^3.0.3",
         "tslib": "^1.10.0",
         "upper-case-first": "^2.0.1"
-      },
-      "dependencies": {
-        "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-          "dev": true,
-          "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
-          }
-        }
       }
     },
     "serialize-error": {
@@ -18419,10 +18268,13 @@
       }
     },
     "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "serve-static": {
       "version": "1.14.1",
@@ -18759,6 +18611,17 @@
         "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.3.0",
         "socket.io-parser": "~3.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "socket.io-adapter": {
@@ -18789,16 +18652,19 @@
         "to-array": "0.1.4"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "socket.io-parser": {
@@ -18820,6 +18686,12 @@
               "requires": {
                 "ms": "2.0.0"
               }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
             }
           }
         }
@@ -18836,6 +18708,15 @@
         "isarray": "2.0.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
@@ -18912,92 +18793,92 @@
       "dev": true
     },
     "sparqlalgebrajs": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.3.2.tgz",
-      "integrity": "sha512-QnjSz25c6ruALbxxD7e9E64hoi/yPMz5MzxUIjLEiTob2zWoM4Pj6GlYZAMnxcCdXXURZO+n0Obt/8XhQj4XiQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.4.0.tgz",
+      "integrity": "sha512-6glKn1uWBsdPuQ4D+4r5m8mgWZoMfiNgip4uyblULTmgISqcbsQzrlrIhWQoZSX95QLLlWlYJufhelQAIRAWKg==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.2",
         "fast-deep-equal": "^3.1.1",
         "minimist": "^1.2.5",
-        "rdf-string": "^1.3.1",
+        "rdf-data-factory": "^1.0.0",
+        "rdf-string": "^1.5.0",
         "sparqljs": "^3.1.1"
       }
     },
     "sparqlee": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.4.3.tgz",
-      "integrity": "sha512-HVWj816xZqUO14/kkA9I/OS+uF8zHe7MGCmoGb4gPcO2KcenF8hg4SssftcQgxVJzsI4RQV91rXhDYdBb1WF9g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.5.0.tgz",
+      "integrity": "sha512-JJadjyDjiZFbkVYz0b0nymQgMboRUJRIrFmx9E9eu07PdOMpPl9PaZo8e8E5GnUW9uaQtG2bm5sFwJvOM6ZbEQ==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
         "@types/create-hash": "^1.2.0",
-        "@types/rdf-js": "^3.0.0",
+        "@types/rdf-js": "*",
         "@types/uuid": "^8.0.0",
         "create-hash": "^1.2.0",
         "decimal.js": "^10.2.0",
         "immutable": "^3.8.2",
-        "rdf-string": "^1.1.1",
-        "sparqlalgebrajs": "^2.1.0",
-        "uri-js": "^4.2.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "relative-to-absolute-iri": "^1.0.6",
+        "sparqlalgebrajs": "^2.4.0",
         "uuid": "^8.0.0"
       }
     },
     "sparqljs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.1.1.tgz",
-      "integrity": "sha512-HYSwEu++souL4YjJbRx+3dJ1aNYNuR+BbZdPmdrmD4QMSO14J63BEshpcSURcNRsuriOI+05wo2AaxVvpjhgkg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.1.2.tgz",
+      "integrity": "sha512-HceS9IUt/ojG75FIv6+UwaYX+wYMH0g+pfZwbvHOSLwCESIQvB4yDGe02yLxfNKXpnXGiIpEaJr5NsYUjI/QWQ==",
       "dev": true,
       "requires": {
         "n3": "^1.6.0"
       }
     },
     "sparqljson-parse": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.5.2.tgz",
-      "integrity": "sha512-VnYzLsiha3Byb7iKr4qbwsztF7cjZFDEnJg2Z2fSbVlUOa4Pwk4cHem6SnFDBWRrOtu/N98v9/JMVRi6bQYqew==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.6.0.tgz",
+      "integrity": "sha512-alIiURVr3AXIGU6fjuh5k6fwINwGKBQu5QnN9TEpoyIRvukKxZLQE07AHsw/Wxhkxico81tPf8nJTx7H1ira5A==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
         "@types/node": "^13.1.0",
-        "@types/rdf-js": "^3.0.0",
-        "JSONStream": "^1.3.3"
+        "@types/rdf-js": "*",
+        "JSONStream": "^1.3.3",
+        "rdf-data-factory": "^1.0.2"
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
-          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+          "version": "13.13.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz",
+          "integrity": "sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ==",
           "dev": true
         }
       }
     },
     "sparqljson-to-tree": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-2.0.0.tgz",
-      "integrity": "sha512-+2R6RtLYm5A3zA/SzIU/6RCp8lM2KQfJpos53BmkgRnHHHvP/ZVtMMnqY9IsV3msMLSCa/D/rS51ND8nCPwRoQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-2.1.0.tgz",
+      "integrity": "sha512-LwEMlrvjzEigatJ8iw1RKGWL9dKmATQNbTEXyadzsOQxbBhJNaGk8G9/WPCcVj2zlCPKGMysfNGb4UfvwHKeSw==",
       "dev": true,
       "requires": {
-        "rdf-literal": "^1.0.0",
-        "sparqljson-parse": "^1.5.0"
+        "rdf-literal": "^1.2.0",
+        "sparqljson-parse": "^1.6.0"
       }
     },
     "sparqlxml-parse": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.3.0.tgz",
-      "integrity": "sha512-NeI5t7Jglue/CIl1LXAAXzK4k9Ex4ULuPpTShuEpID+edPmljJ17ITsgx1yM8exZR1a4br5UqyyiDxduQQ4wAw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.4.0.tgz",
+      "integrity": "sha512-hKYsRw+KHIF4QXpMtybCSkfVhoQmTdUrUe5WkYnlyyw+3aeskIDnd97TPQi7MNSok2aim02osqkHvWQFNGXm3A==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
         "@types/node": "^13.1.0",
-        "@types/rdf-js": "^3.0.0",
+        "@types/rdf-js": "*",
+        "rdf-data-factory": "^1.0.2",
         "sax-stream": "^1.2.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
-          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+          "version": "13.13.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz",
+          "integrity": "sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ==",
           "dev": true
         }
       }
@@ -19029,9 +18910,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
       "dev": true
     },
     "split-string": {
@@ -19354,9 +19235,9 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+          "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
           "dev": true,
           "requires": {
             "is-obj": "^2.0.0"
@@ -19434,9 +19315,9 @@
       }
     },
     "systemjs": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.5.0.tgz",
-      "integrity": "sha512-B+NzKJD1srC/URfNVBdDExAUAsAVXpVQxZxX54AtqU0xiK9imkqurQu3qi6JdyA2GBAw2ssjolYIa7kh+xY1uw==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.6.1.tgz",
+      "integrity": "sha512-Niw/DZwTPmdLGC0CCe+n/MdRu927XyN/jzxKZyU6tUfeNqGQlxO5oVXuVMsJHxPO2cnXyHh0/zIGdXaocOMLVQ==",
       "dev": true
     },
     "table": {
@@ -19552,12 +19433,12 @@
           }
         },
         "tar-stream": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-          "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+          "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
           "dev": true,
           "requires": {
-            "bl": "^4.0.1",
+            "bl": "^4.0.3",
             "end-of-stream": "^1.4.1",
             "fs-constants": "^1.0.0",
             "inherits": "^2.0.3",
@@ -19617,6 +19498,12 @@
         "source-map-support": "~0.5.12"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -20067,15 +19954,15 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+      "version": "0.7.22",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.2.tgz",
-      "integrity": "sha512-GXCYNwqoo0MbLARghYjxVBxDCnU0tLqN7IPLdHHbibCb1NI5zBkU2EPcy/GaVxc0BtTjqyGXJCINe6JMR2Dpow==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.0.tgz",
+      "integrity": "sha512-e1KQFRCpOxnrJsJVqDUCjURq+wXvIn7cK2sRAx9XL3HYLL9aezOP4Pb1+Y3/o693EPk111Yj2Q+IUXxcpHlygQ==",
       "dev": true
     },
     "ultron": {
@@ -20314,10 +20201,13 @@
       "dev": true
     },
     "upper-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz",
+      "integrity": "sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.10.0"
+      }
     },
     "upper-case-first": {
       "version": "2.0.1",
@@ -20329,9 +20219,9 @@
       }
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -20602,34 +20492,34 @@
       "dev": true
     },
     "webdriver": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.4.2.tgz",
-      "integrity": "sha512-8aj6zSxI9B9/O9DKiBUNc0BcmtEWHFcgeoVn0IqytTWN+M30UVrl1PuWPqrp2wTWMlW4ZAOW1ifnPQOBxbbniQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.5.0.tgz",
+      "integrity": "sha512-6iOll9TshD4+2J+em+bLshvM1uXtnotdZ+JaALqRLbkVswLRFU0pTVP1oug0e/IYwL7Me4Cafh9ugQ4PwPuOnA==",
       "dev": true,
       "requires": {
-        "@wdio/config": "6.1.14",
-        "@wdio/logger": "6.0.16",
+        "@wdio/config": "6.4.7",
+        "@wdio/logger": "6.4.7",
         "@wdio/protocols": "6.3.6",
-        "@wdio/utils": "6.4.0",
+        "@wdio/utils": "6.5.0",
         "got": "^11.0.2",
         "lodash.merge": "^4.6.1"
       }
     },
     "webdriverio": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.4.4.tgz",
-      "integrity": "sha512-KmioPyB9JysQN+4Gwe3LRK5CLFwZp6T4S+oI8aFMUVUBbp7zJuosq8oLI1wJzTaysInotNldOCOC3dEIVjNyuQ==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.5.2.tgz",
+      "integrity": "sha512-ChAV6RmF10mlyWnAL2y+PdnzAjpxL/UuyAHJsYSuirEeEAAqFWWePxniz67bUEVQPVClVj8Jh7oeoK6rhu4RAA==",
       "dev": true,
       "requires": {
         "@types/puppeteer": "^3.0.1",
-        "@wdio/config": "6.1.14",
-        "@wdio/logger": "6.0.16",
-        "@wdio/repl": "6.4.0",
-        "@wdio/utils": "6.4.0",
+        "@wdio/config": "6.4.7",
+        "@wdio/logger": "6.4.7",
+        "@wdio/repl": "6.5.0",
+        "@wdio/utils": "6.5.0",
         "archiver": "^5.0.0",
         "atob": "^2.1.2",
         "css-value": "^0.0.1",
-        "devtools": "6.4.4",
+        "devtools": "6.5.0",
         "get-port": "^5.1.1",
         "grapheme-splitter": "^1.0.2",
         "lodash.clonedeep": "^4.5.0",
@@ -20641,7 +20531,7 @@
         "resq": "^1.6.0",
         "rgb2hex": "^0.2.0",
         "serialize-error": "^7.0.0",
-        "webdriver": "6.4.2"
+        "webdriver": "6.5.0"
       }
     },
     "webidl-conversions": {
@@ -20651,9 +20541,9 @@
       "dev": true
     },
     "whatwg-fetch": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
-      "integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
+      "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==",
       "dev": true
     },
     "whatwg-url": {
@@ -20761,27 +20651,27 @@
       }
     },
     "workbox-background-sync": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-5.1.3.tgz",
-      "integrity": "sha512-V/R95aPxYjbKCaVzUTihrZ9ObGOnzoA5n60r0DQ747p8Pj15/dDTYixonKhhlvavTiNezUrp+wTQBvZvcd/ETA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-5.1.4.tgz",
+      "integrity": "sha512-AH6x5pYq4vwQvfRDWH+vfOePfPIYQ00nCEB7dJRU1e0n9+9HMRyvI63FlDvtFT2AvXVRsXvUt7DNMEToyJLpSA==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3"
+        "workbox-core": "^5.1.4"
       }
     },
     "workbox-broadcast-update": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-5.1.3.tgz",
-      "integrity": "sha512-HJ7FDmgweRcYp8fMiFbkmhaTjMYhMByURe5+TempnCi7cT5NNbyaG4T+rg8NWYxAeumSAB3JQF6XD/z34vRRHA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-5.1.4.tgz",
+      "integrity": "sha512-HTyTWkqXvHRuqY73XrwvXPud/FN6x3ROzkfFPsRjtw/kGZuZkPzfeH531qdUGfhtwjmtO/ZzXcWErqVzJNdXaA==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3"
+        "workbox-core": "^5.1.4"
       }
     },
     "workbox-build": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-5.1.3.tgz",
-      "integrity": "sha512-cssa2cKAi/FNp2P2m2DjF/UsXlVX6b1HgkXOjBTraFkIeyZEKxN1F1DnxOpGkdM/bPPRa7y5OmUvjOpgOd9apA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-5.1.4.tgz",
+      "integrity": "sha512-xUcZn6SYU8usjOlfLb9Y2/f86Gdo+fy1fXgH8tJHjxgpo53VVsqRX0lUDw8/JuyzNmXuo8vXX14pXX2oIm9Bow==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.8.4",
@@ -20799,27 +20689,27 @@
         "pretty-bytes": "^5.3.0",
         "rollup": "^1.31.1",
         "rollup-plugin-babel": "^4.3.3",
-        "rollup-plugin-terser": "^5.2.0",
+        "rollup-plugin-terser": "^5.3.1",
         "source-map": "^0.7.3",
         "source-map-url": "^0.4.0",
         "stringify-object": "^3.3.0",
         "strip-comments": "^1.0.2",
         "tempy": "^0.3.0",
         "upath": "^1.2.0",
-        "workbox-background-sync": "^5.1.3",
-        "workbox-broadcast-update": "^5.1.3",
-        "workbox-cacheable-response": "^5.1.3",
-        "workbox-core": "^5.1.3",
-        "workbox-expiration": "^5.1.3",
-        "workbox-google-analytics": "^5.1.3",
-        "workbox-navigation-preload": "^5.1.3",
-        "workbox-precaching": "^5.1.3",
-        "workbox-range-requests": "^5.1.3",
-        "workbox-routing": "^5.1.3",
-        "workbox-strategies": "^5.1.3",
-        "workbox-streams": "^5.1.3",
-        "workbox-sw": "^5.1.3",
-        "workbox-window": "^5.1.3"
+        "workbox-background-sync": "^5.1.4",
+        "workbox-broadcast-update": "^5.1.4",
+        "workbox-cacheable-response": "^5.1.4",
+        "workbox-core": "^5.1.4",
+        "workbox-expiration": "^5.1.4",
+        "workbox-google-analytics": "^5.1.4",
+        "workbox-navigation-preload": "^5.1.4",
+        "workbox-precaching": "^5.1.4",
+        "workbox-range-requests": "^5.1.4",
+        "workbox-routing": "^5.1.4",
+        "workbox-strategies": "^5.1.4",
+        "workbox-streams": "^5.1.4",
+        "workbox-sw": "^5.1.4",
+        "workbox-window": "^5.1.4"
       },
       "dependencies": {
         "fs-extra": {
@@ -20833,6 +20723,16 @@
             "universalify": "^0.1.0"
           }
         },
+        "jest-worker": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+          "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+          "dev": true,
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^6.1.0"
+          }
+        },
         "rollup": {
           "version": "1.32.1",
           "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
@@ -20844,119 +20744,141 @@
             "acorn": "^7.1.0"
           }
         },
+        "rollup-plugin-terser": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz",
+          "integrity": "sha512-1pkwkervMJQGFYvM9nscrUoncPwiKR/K+bHdjv6PFgRo3cgPHoRT83y2Aa3GvINj4539S15t/tpFPb775TDs6w==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "jest-worker": "^24.9.0",
+            "rollup-pluginutils": "^2.8.2",
+            "serialize-javascript": "^4.0.0",
+            "terser": "^4.6.2"
+          }
+        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
     "workbox-cacheable-response": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-5.1.3.tgz",
-      "integrity": "sha512-lOJEwK2T4KWFNdhRFUKxTPBIO5hIYm9E/nYgMq5h/IH3iHPHlBPuFwRMaQy+TTCGWWTA85NomQOjVw1bj65RLw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-5.1.4.tgz",
+      "integrity": "sha512-0bfvMZs0Of1S5cdswfQK0BXt6ulU5kVD4lwer2CeI+03czHprXR3V4Y8lPTooamn7eHP8Iywi5QjyAMjw0qauA==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3"
+        "workbox-core": "^5.1.4"
       }
     },
     "workbox-core": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-5.1.3.tgz",
-      "integrity": "sha512-TFSIPxxciX9sFaj0FDiohBeIKpwMcCyNduydi9i3LChItcndDS6TJpErxybv8aBWeCMraXt33TWtF6kKuIObNw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-5.1.4.tgz",
+      "integrity": "sha512-+4iRQan/1D8I81nR2L5vcbaaFskZC2CL17TLbvWVzQ4qiF/ytOGF6XeV54pVxAvKUtkLANhk8TyIUMtiMw2oDg==",
       "dev": true
     },
     "workbox-expiration": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-5.1.3.tgz",
-      "integrity": "sha512-8YhpmIHqIx+xmtxONADc+di4a3zzCsvVHLiKq6T3vJZUPnqV2jzx+51+UHMUh3T5w5Z5SFC14l0V/jesRbuMKg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-5.1.4.tgz",
+      "integrity": "sha512-oDO/5iC65h2Eq7jctAv858W2+CeRW5e0jZBMNRXpzp0ZPvuT6GblUiHnAsC5W5lANs1QS9atVOm4ifrBiYY7AQ==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3"
+        "workbox-core": "^5.1.4"
       }
     },
     "workbox-google-analytics": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-5.1.3.tgz",
-      "integrity": "sha512-ouK6xIJa+raFcO29TgwKFU/Hv1ejqSYzCzH9lI2B/4z/Wdnb8maL6mMIojQ8j5SohwKswMZmLDl0Az2PCmX11w==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-5.1.4.tgz",
+      "integrity": "sha512-0IFhKoEVrreHpKgcOoddV+oIaVXBFKXUzJVBI+nb0bxmcwYuZMdteBTp8AEDJacENtc9xbR0wa9RDCnYsCDLjA==",
       "dev": true,
       "requires": {
-        "workbox-background-sync": "^5.1.3",
-        "workbox-core": "^5.1.3",
-        "workbox-routing": "^5.1.3",
-        "workbox-strategies": "^5.1.3"
+        "workbox-background-sync": "^5.1.4",
+        "workbox-core": "^5.1.4",
+        "workbox-routing": "^5.1.4",
+        "workbox-strategies": "^5.1.4"
       }
     },
     "workbox-navigation-preload": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-5.1.3.tgz",
-      "integrity": "sha512-29SPQMAccOgbq3BT9Gz7k+ydy0mcKKR0Rmkmd46tnujutiL4ooE57fBhwsA+c6OlLcYdisvilKlV2YWEtKWfgQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-5.1.4.tgz",
+      "integrity": "sha512-Wf03osvK0wTflAfKXba//QmWC5BIaIZARU03JIhAEO2wSB2BDROWI8Q/zmianf54kdV7e1eLaIEZhth4K4MyfQ==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3"
+        "workbox-core": "^5.1.4"
       }
     },
     "workbox-precaching": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-5.1.3.tgz",
-      "integrity": "sha512-9jjBiB00AOI0NnI320ddnhvlL3bjMrDoI3211kEaxcRWh0N2fX25uVn0O8N8u1gWY4tIfwZAn/DgtAU13cFhYA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-5.1.4.tgz",
+      "integrity": "sha512-gCIFrBXmVQLFwvAzuGLCmkUYGVhBb7D1k/IL7pUJUO5xacjLcFUaLnnsoVepBGAiKw34HU1y/YuqvTKim9qAZA==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3"
+        "workbox-core": "^5.1.4"
       }
     },
     "workbox-range-requests": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-5.1.3.tgz",
-      "integrity": "sha512-uUvEoyEUx86LJc7mtmy/6U8xuK0guXU2FnPimt17zDbsC8FSOaPxc92rxtD6xmDSYrI4FqIebypBCjgIe+sfxA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-5.1.4.tgz",
+      "integrity": "sha512-1HSujLjgTeoxHrMR2muDW2dKdxqCGMc1KbeyGcmjZZAizJTFwu7CWLDmLv6O1ceWYrhfuLFJO+umYMddk2XMhw==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3"
+        "workbox-core": "^5.1.4"
       }
     },
     "workbox-routing": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-5.1.3.tgz",
-      "integrity": "sha512-F+sAp9Iy3lVl3BEG+pzXWVq4AftzjiFpHDaZ4Kf4vLoBoKQE0hIHet4zE5DpHqYdyw+Udhp4wrfHamX6PN6z1Q==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-5.1.4.tgz",
+      "integrity": "sha512-8ljknRfqE1vEQtnMtzfksL+UXO822jJlHTIR7+BtJuxQ17+WPZfsHqvk1ynR/v0EHik4x2+826Hkwpgh4GKDCw==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3"
+        "workbox-core": "^5.1.4"
       }
     },
     "workbox-strategies": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-5.1.3.tgz",
-      "integrity": "sha512-wiXHfmOKnWABeIVW+/ye0e00+2CcS5y7SIj2f9zcdy2ZLEbcOf7B+yOl5OrWpBGlTUwRjIYhV++ZqiKm3Dc+8w==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-5.1.4.tgz",
+      "integrity": "sha512-VVS57LpaJTdjW3RgZvPwX0NlhNmscR7OQ9bP+N/34cYMDzXLyA6kqWffP6QKXSkca1OFo/v6v7hW7zrrguo6EA==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3",
-        "workbox-routing": "^5.1.3"
+        "workbox-core": "^5.1.4",
+        "workbox-routing": "^5.1.4"
       }
     },
     "workbox-streams": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-5.1.3.tgz",
-      "integrity": "sha512-8kt70eBd1RXL0qenxEnch3Cd7VyW3O0CkeGBN4Bikt307nIV5Q0JciLA5o0CRteijawYOiTq0/px4GDBv1obgQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-5.1.4.tgz",
+      "integrity": "sha512-xU8yuF1hI/XcVhJUAfbQLa1guQUhdLMPQJkdT0kn6HP5CwiPOGiXnSFq80rAG4b1kJUChQQIGPrq439FQUNVrw==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3",
-        "workbox-routing": "^5.1.3"
+        "workbox-core": "^5.1.4",
+        "workbox-routing": "^5.1.4"
       }
     },
     "workbox-sw": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-5.1.3.tgz",
-      "integrity": "sha512-Syk6RhYr/8VdFwXrxo5IpVz8Og2xapHTWJhqsZRF+TbxSvlaJs8hrvVPd7edn5ZiiVdPhE9NTeOTOg1+D+FGoA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-5.1.4.tgz",
+      "integrity": "sha512-9xKnKw95aXwSNc8kk8gki4HU0g0W6KXu+xks7wFuC7h0sembFnTrKtckqZxbSod41TDaGh+gWUA5IRXrL0ECRA==",
       "dev": true
     },
     "workbox-window": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-5.1.3.tgz",
-      "integrity": "sha512-oYvfVtPLET7FUrhOzbk0R+aATVmpdQBkmDqwyFH4W2dfVqJXTvTXzuGP5Pn9oZ8jMTB3AYW43yhYBlLYM3mYyg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-5.1.4.tgz",
+      "integrity": "sha512-vXQtgTeMCUq/4pBWMfQX8Ee7N2wVC4Q7XYFqLnfbXJ2hqew/cU1uMTD2KqGEgEpE4/30luxIxgE+LkIa8glBYw==",
       "dev": true,
       "requires": {
-        "workbox-core": "^5.1.3"
+        "workbox-core": "^5.1.4"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-console",
   "description": "The API Console to automatically generate API documentation from RAML and OAS files.",
-  "version": "6.2.5",
+  "version": "6.2.6",
   "license": "CPAL-1.0",
   "main": "index.js",
   "module": "index.js",


### PR DESCRIPTION
## Bug fixes
- Fixed bug example generation for partial models where some properties would not appear in rendered example if their values were empty strings, `false` boolean values or `0` integer values
- Fixed bug in type documentation where enum array properties weren't being rendered correctly
- Fixed bug where the `queryString` node was defined on an operation, but the query parameters didn't render in the try it panel
- Fixed bug where XML example structures did not match the definition in the RAML type
- Fixed bug where JSON schemas in RAML did not render completely