### PR TITLE
v6.3.2

### DIFF
--- a/demo/element/app.js
+++ b/demo/element/app.js
@@ -21,6 +21,7 @@ class ApicApplication extends DemoBase {
       ['demo-api', 'Demo API'],
       ['multi-server', 'Multi Server API'],
       ['oas-3-api', 'OAS 3 API'],
+      ['async-api', 'AsyncAPI'],
     ];
 
     this.toggleConsoleMenu = this.toggleConsoleMenu.bind(this);

--- a/package-lock.json
+++ b/package-lock.json
@@ -888,9 +888,9 @@
       }
     },
     "@api-components/api-method-documentation": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-method-documentation/-/api-method-documentation-5.1.0.tgz",
-      "integrity": "sha512-mNac+lmPYfve3xb5C1+zgG8V34DYbU5NdVKVgsCV5nvBN28DgguweFmAudzQMHV2cT1JgfZTSWfLW2VXkkg6rw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@api-components/api-method-documentation/-/api-method-documentation-5.1.1.tgz",
+      "integrity": "sha512-vMxsqGtW8cUgLb5kndIVszzZp2WSdG/cRCVRJelXc/ZvVRmLAySFcTfRjOLy3ZPC2VfDu4s2vPfACTBvMu3CRw==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.0.5",
         "@advanced-rest-client/arc-marked": "^1.0.6",
@@ -1013,14 +1013,13 @@
       }
     },
     "@api-components/api-request-panel": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-request-panel/-/api-request-panel-5.1.0.tgz",
-      "integrity": "sha512-gh24fWRUg3uG3FUSS4oFUZcBi25urRF0YbptvR6tEyvzwIDxKp0S664b+LW+WTj//v4F2GcDuFEVt6mCeztelA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@api-components/api-request-panel/-/api-request-panel-5.1.1.tgz",
+      "integrity": "sha512-x4AJtJwpF+BX8SDsVNT/42uW6Ds1mKhondOjiuFMSWrQNYKLTAUm/P6MqhoGC3LgCV44EgMOd/gG6abUDp44cQ==",
       "requires": {
         "@advanced-rest-client/events-target-mixin": "^3.2.0",
         "@advanced-rest-client/headers-parser-mixin": "^3.2.0",
         "@advanced-rest-client/response-view": "^3.0.4",
-        "@api-components/amf-helper-mixin": "^4.3.0",
         "@api-components/api-request-editor": "^5.0.3",
         "@api-components/raml-aware": "^3.0.0",
         "lit-element": "^2.3.1",
@@ -5526,10 +5525,13 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -6809,16 +6811,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.14.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
-      "integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz",
+      "integrity": "sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001157",
+        "caniuse-lite": "^1.0.30001164",
         "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.591",
+        "electron-to-chromium": "^1.3.612",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.66"
+        "node-releases": "^1.1.67"
       }
     },
     "browserslist-useragent": {
@@ -6833,10 +6835,13 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -7026,13 +7031,21 @@
       "dev": true
     },
     "camel-case": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
-      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
       "dev": true,
       "requires": {
-        "pascal-case": "^3.1.1",
-        "tslib": "^1.10.0"
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
       }
     },
     "camelcase": {
@@ -8018,10 +8031,13 @@
           }
         },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "strip-indent": {
           "version": "3.0.0",
@@ -8596,9 +8612,9 @@
           },
           "dependencies": {
             "domelementtype": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
-              "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+              "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
               "dev": true
             }
           }
@@ -9165,9 +9181,9 @@
       }
     },
     "domelementtype": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
-      "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
       "dev": true
     },
     "domhandler": {
@@ -9185,24 +9201,43 @@
       "integrity": "sha512-BsGR4nDLaC5CNBnyT5I+d5pOeaoWvgVeg6Gq/aqmKYWMPR07131u60I80BvExLAJ0FQEIBQ1BTicw+C5+jOyrg=="
     },
     "domutils": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz",
-      "integrity": "sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.3.tgz",
+      "integrity": "sha512-MDMfEjgtzHvRX7i21XQfkk/vfZbLOe0VJk8dDETkTTo3BTeH3NXz3Xvs94UQ+GzTw/GjRYKsfVKIIOheYX63fw==",
       "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
-        "domhandler": "^3.3.0"
+        "domhandler": "^4.0.0"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.1.0"
+          }
+        }
       }
     },
     "dot-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
-      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
       "dev": true,
       "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
       }
     },
     "dot-prop": {
@@ -9284,9 +9319,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.612",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.612.tgz",
-      "integrity": "sha512-CdrdX1B6mQqxfw+51MPWB5qA6TKWjza9f5voBtUlRfEZEwZiFaxJLrhFI8zHE9SBAuGt4h84rQU6Ho9Bauo1LA==",
+      "version": "1.3.614",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.614.tgz",
+      "integrity": "sha512-JMDl46mg4G+n6q/hAJkwy9eMTj5FJjsE+8f/irAGRMLM4yeRVbMuRrdZrbbGGOrGVcZc4vJPjUpEUWNb/fA6hg==",
       "dev": true
     },
     "emoji-regex": {
@@ -9455,9 +9490,9 @@
       }
     },
     "es-dev-server": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.58.0.tgz",
-      "integrity": "sha512-IT0ipJDmr0WnpzvVpgaYCB+id31bbXQOn93Wfi8vCwGUU/cHlk+5uB7SRWsWP8qFzCsar7Fn35yKRXljbbZt3w==",
+      "version": "1.60.1",
+      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.60.1.tgz",
+      "integrity": "sha512-7/bn3j51qqQ+D9EKu3vup44XhRGzhNKwTf7MPykv9j7NucIw5BlRJCL0rqMXDF7MCiRiS1RRgblKM7dNKBIp5g==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.1",
@@ -10937,10 +10972,13 @@
           }
         },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "strip-indent": {
           "version": "3.0.0",
@@ -11990,9 +12028,9 @@
       "dev": true
     },
     "is-generator-function": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
-      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
+      "integrity": "sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ==",
       "dev": true
     },
     "is-glob": {
@@ -13331,12 +13369,20 @@
       }
     },
     "lower-case": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "dev": true,
       "requires": {
-        "tslib": "^1.10.0"
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
       }
     },
     "lru-cache": {
@@ -14085,13 +14131,21 @@
       }
     },
     "no-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
       "dev": true,
       "requires": {
-        "lower-case": "^2.0.1",
-        "tslib": "^1.10.0"
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
       }
     },
     "node-cache": {
@@ -14466,13 +14520,21 @@
       "dev": true
     },
     "param-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
-      "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
       "dev": true,
       "requires": {
-        "dot-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
       }
     },
     "parent-module": {
@@ -14553,13 +14615,21 @@
       "dev": true
     },
     "pascal-case": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
-      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
       "dev": true,
       "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
       }
     },
     "pascalcase": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api-console",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-console",
   "description": "The API Console to automatically generate API documentation from RAML and OAS files.",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "license": "CPAL-1.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiConsole.js
+++ b/src/ApiConsole.js
@@ -452,6 +452,9 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
     }
     const webApi = this.webApi = this._computeApi(amf);
     this.methodName = this._computeMethodName(this.selectedShape, webApi);
+    if (!this._isWebAPI(amf)) {
+      this._noTryItValue = true;
+    }
   }
 
   /**

--- a/src/ApiConsoleApp.js
+++ b/src/ApiConsoleApp.js
@@ -199,11 +199,17 @@ export class ApiConsoleApp extends ApiConsole {
     if (!wideLayout || !isMethod ||inlineMethods) {
       return false;
     }
+    if (!this._isWebAPI(this.amf)) {
+      return false;
+    }
     return wideLayout;
   }
 
   _computeNoTryItValue(noTryIt, renderInlineTyit) {
     if (renderInlineTyit) {
+      return true;
+    }
+    if (!this._isWebAPI(this.amf)) {
       return true;
     }
     return noTryIt;

--- a/test/api-console.amf.test.js
+++ b/test/api-console.amf.test.js
@@ -202,8 +202,8 @@ describe('<api-console>', function() {
 
         it('should have _noTryItValue set to true', () => {
           assert.isTrue(element._noTryItValue);
-        })
-      })
-    })
-  })
+        });
+      });
+    });
+  });
 });

--- a/test/api-console.amf.test.js
+++ b/test/api-console.amf.test.js
@@ -181,4 +181,29 @@ describe('<api-console>', function() {
       });
     });
   });
+
+  describe.only('AsyncAPI', () => {
+    [
+      new ApiDescribe('Regular model'),
+      new ApiDescribe('Compact model', true),
+    ].forEach(({ label, compact }) => {
+      describe(label, () => {
+        let amf;
+        let element;
+
+        before(async () => {
+          amf = await AmfLoader.load({ compact, fileName: 'async-api' });
+        });
+
+        beforeEach(async () => {
+          element = await amfFixture(amf);
+          await aTimeout(0);
+        });
+
+        it('should have _noTryItValue set to true', () => {
+          assert.isTrue(element._noTryItValue);
+        })
+      })
+    })
+  })
 });

--- a/test/api-console.amf.test.js
+++ b/test/api-console.amf.test.js
@@ -182,7 +182,7 @@ describe('<api-console>', function() {
     });
   });
 
-  describe.only('AsyncAPI', () => {
+  describe('AsyncAPI', () => {
     [
       new ApiDescribe('Regular model'),
       new ApiDescribe('Compact model', true),


### PR DESCRIPTION
# Fixes
- Fixed bug where `baseUri` on `api-method-documentation` was not propagating the change to `api-url`

# Features
- `api-request-panel` does not return empty content if model does not belong to a WebAPI. This behavior is expected of whoever renders it
- `api-console` and `api-console-app` check if AMF belongs to a non WebAPI, and hide the request panel & propagate the `noTryIt` accordingly