### PR TITLE
Change package name for Valkyr pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api-console",
+  "name": "@mulesoft/api-console",
   "description": "The API Console to automatically generate API documentation from RAML and OAS files.",
   "version": "0.0.0-valkyr",
   "license": "CPAL-1.0",


### PR DESCRIPTION
`api-console` -> `@mulesoft/api-console`


We still need to maintain visibility that the public package name will continue to be `api-console`