### PR TITLE
Remove OAuth helpers elements

### DIFF
--- a/demo/editor/app.js
+++ b/demo/editor/app.js
@@ -186,8 +186,6 @@ protocols: [HTTP, HTTPS]
     </main>
 
     <xhr-simple-request></xhr-simple-request>
-    <oauth1-authorization></oauth1-authorization>
-    <oauth2-authorization></oauth2-authorization>
     `;
   }
 

--- a/demo/element/app.js
+++ b/demo/element/app.js
@@ -62,8 +62,6 @@ class ApicApplication extends DemoBase {
       </api-console>
 
       <xhr-simple-request></xhr-simple-request>
-      <oauth1-authorization></oauth1-authorization>
-      <oauth2-authorization></oauth2-authorization>
 
       <div class="footer">
         Brought to you with ❤ by MuleSoft. A Salesforce company.

--- a/src/ApiConsoleApp.js
+++ b/src/ApiConsoleApp.js
@@ -426,7 +426,6 @@ export class ApiConsoleApp extends ApiConsole {
       .appendHeaders="${this.appendHeaders}"
       .proxy="${this.proxy}"
       .proxyEncodeUrl="${this.proxyEncodeUrl}"></xhr-simple-request>
-    <oauth1-authorization></oauth1-authorization>
-    <oauth2-authorization></oauth2-authorization>`;
+      `;
   }
 }


### PR DESCRIPTION
As mentioned in #678 

OAuth helper elements are now found in the `api-request` component, and should therefore be removed from `api-console-app`