### PR TITLE
[W14071465] Editing code while Console is opened changes the MS URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1182,9 +1182,9 @@
       }
     },
     "node_modules/@api-components/api-request": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@api-components/api-request/-/api-request-0.3.7.tgz",
-      "integrity": "sha512-I/XGWQR8tFVEamfQhz3JOXTYyYGTXOWsxe+AuqLSuGTFn1czlf1Mti5gi6vpmH8pDVkH7zDX1fih3NOWQSXI8w==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@api-components/api-request/-/api-request-0.3.8.tgz",
+      "integrity": "sha512-HN2YcvnqywFR7+W7SxoDZ6u0tB6Fee9nafIhbgdaUoxvIToXxPpDUEP1iNbpT0+DfXxggG583hSseZPExTwGYw==",
       "dependencies": {
         "@advanced-rest-client/arc-events": "^0.2.13",
         "@advanced-rest-client/arc-headers": "^0.1.7",
@@ -24893,9 +24893,9 @@
       }
     },
     "@api-components/api-request": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@api-components/api-request/-/api-request-0.3.7.tgz",
-      "integrity": "sha512-I/XGWQR8tFVEamfQhz3JOXTYyYGTXOWsxe+AuqLSuGTFn1czlf1Mti5gi6vpmH8pDVkH7zDX1fih3NOWQSXI8w==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@api-components/api-request/-/api-request-0.3.8.tgz",
+      "integrity": "sha512-HN2YcvnqywFR7+W7SxoDZ6u0tB6Fee9nafIhbgdaUoxvIToXxPpDUEP1iNbpT0+DfXxggG583hSseZPExTwGYw==",
       "requires": {
         "@advanced-rest-client/arc-events": "^0.2.13",
         "@advanced-rest-client/arc-headers": "^0.1.7",

--- a/src/ApiConsole.js
+++ b/src/ApiConsole.js
@@ -1,4 +1,3 @@
-/* eslint-disable lit-a11y/click-events-have-key-events */
 /**
 @license
 Copyright 2018 The Advanced REST client authors <arc@mulesoft.com>
@@ -370,6 +369,7 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
     super();
     this._tryitHandler = this._tryitHandler.bind(this);
     this._handleServerChange = this._handleServerChange.bind(this);
+    this._handleSelectionChange = this._handleSelectionChange.bind(this);
 
     this.page = 'docs';
     this.compatibility = false;
@@ -659,6 +659,15 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
     this.serverValue = value;
   }
 
+  /**
+   * Handler for the `apiselectionchange` event dispatched from the components.
+   * @param {CustomEvent} e
+   */
+  _handleSelectionChange(e) {
+    const { value } = e.detail;
+    this.selectedShape = value;
+  }
+
   render() {
     return html`
     ${this._mainContentTemplate()}
@@ -769,6 +778,7 @@ export class ApiConsole extends AmfHelperMixin(LitElement) {
       .eventsTarget="${eventsTarget}"
       .credentialsSource="${credentialsSource}"
       ?persistCache="${persistCache}"
+      @api-request-panel-selection-changed="${this._handleSelectionChange}"
       >
         <slot name="custom-base-uri" slot="custom-base-uri"></slot>
       </api-request-panel>`;


### PR DESCRIPTION
# Solution description:

When the AMF model changes, save the operation old and find this operation in the new AMF -> [PR](https://github.com/advanced-rest-client/api-request/pull/40), then dispatch an event in the Api-Console to set the newly selected shape.

- Updated @api-components/api-request to version 0.3.8
# Result: 
https://github.com/advanced-rest-client/api-request/assets/96145153/7d250822-3ba5-4679-a2ab-3a9bf006aa71

