### PR TITLE
W-19424007 (SPIKE) Try Panel gRPC support with new proto definitions

### DIFF
--- a/demo/themed/anypoint.js
+++ b/demo/themed/anypoint.js
@@ -18,6 +18,7 @@ class ApicApplication extends DemoBase {
       ['data-type-fragment', 'RAML data type fragment'],
       ['demo-api', 'Demo API'],
       ['APIC-538', 'APIC-538'],
+      ['grpc-test', 'GRPC Test'],
     ];
   }
 

--- a/example.proto
+++ b/example.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package example;
+
+// Definición del servicio
+service Greeter {
+  // Método unary (simple request-response)
+  rpc SayHello (HelloRequest) returns (HelloResponse);
+}
+
+// Mensaje de solicitud
+message HelloRequest {
+  string name = 1;
+}
+
+// Mensaje de respuesta
+message HelloResponse {
+  string message = 1;
+}

--- a/grpc.json
+++ b/grpc.json
@@ -1,0 +1,5740 @@
+[
+  {
+    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto",
+    "@type": [
+      "http://a.ml/vocabularies/document#Document",
+      "http://a.ml/vocabularies/document#Fragment",
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/document#encodes": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api",
+        "@type": [
+          "http://a.ml/vocabularies/apiContract#WebAPI",
+          "http://a.ml/vocabularies/apiContract#API",
+          "http://a.ml/vocabularies/document#RootDomainElement",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "helloworld"
+          }
+        ],
+        "http://a.ml/vocabularies/apiContract#endpoint": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#EndPoint",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "Greeter"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#supportedOperation": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Operation",
+                  "http://a.ml/vocabularies/core#Operation",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#method": [
+                  {
+                    "@value": "post"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "SayHello1"
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#expects": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/expects/request",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Request",
+                      "http://a.ml/vocabularies/core#Request",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/expects/request/payload/application%2Fgrpc",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/core#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/grpc",
+                            "__apicResolved": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/expects/request/payload/application%2Fgrpc/shape/HelloRequest",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement",
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": ".helloworld.HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#sources": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map",
+                                "@type": [
+                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/expects/request/payload/application%2Fgrpc/shape/HelloRequest/source-map/synthesized-field/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "http://a.ml/vocabularies/document#link-target"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "true"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map/lexical/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "[(22,0)-(25,1)]",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#declared-element": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map/declared-element/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#property": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name",
+                                "@type": [
+                                  "http://www.w3.org/ns/shacl#PropertyShape",
+                                  "http://www.w3.org/ns/shacl#Shape",
+                                  "http://a.ml/vocabularies/shapes#Shape",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/shapes#range": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/shapes#ArrayShape",
+                                      "http://a.ml/vocabularies/shapes#AnyShape",
+                                      "http://www.w3.org/ns/shacl#Shape",
+                                      "http://a.ml/vocabularies/shapes#Shape",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/shapes#items": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                                          "http://a.ml/vocabularies/shapes#AnyShape",
+                                          "http://www.w3.org/ns/shacl#Shape",
+                                          "http://a.ml/vocabularies/shapes#Shape",
+                                          "http://a.ml/vocabularies/document#DomainElement"
+                                        ],
+                                        "http://www.w3.org/ns/shacl#datatype": [
+                                          {
+                                            "@id": "http://www.w3.org/2001/XMLSchema#string",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar/source-map",
+                                            "@type": [
+                                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                              {
+                                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar/source-map/lexical/element_0",
+                                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                                  {
+                                                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar",
+                                                    "__apicResolved": true
+                                                  }
+                                                ],
+                                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                                  {
+                                                    "@value": "[(23,11)-(23,17)]",
+                                                    "__apicResolved": true
+                                                  }
+                                                ],
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/source-map",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/source-map/lexical/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "[(23,2)-(23,27)]",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                                  {
+                                    "@value": 1,
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#name": [
+                                  {
+                                    "@value": "name",
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/source-map/lexical/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "[(23,2)-(23,27)]",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              },
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus",
+                                "@type": [
+                                  "http://www.w3.org/ns/shacl#PropertyShape",
+                                  "http://www.w3.org/ns/shacl#Shape",
+                                  "http://a.ml/vocabularies/shapes#Shape",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/shapes#range": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus",
+                                    "@type": [
+                                      "http://www.w3.org/ns/shacl#NodeShape",
+                                      "http://a.ml/vocabularies/shapes#AnyShape",
+                                      "http://www.w3.org/ns/shacl#Shape",
+                                      "http://a.ml/vocabularies/shapes#Shape",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/document#link-target": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document#link-label": [
+                                      {
+                                        "@value": "library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://www.w3.org/ns/shacl#name": [
+                                      {
+                                        "@value": "library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map/synthesized-field/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "http://a.ml/vocabularies/document#link-target",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "true",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map/lexical/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "[(24,2)-(24,15)]",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                                  {
+                                    "@value": 2,
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#name": [
+                                  {
+                                    "@value": "wadus",
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/source-map/lexical/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "[(24,2)-(24,26)]",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "__apicResolved": true
+                          }
+                        ],
+                        "__apicResolved": true
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#returns": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/returns/resp/",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Response",
+                      "http://a.ml/vocabularies/core#Response",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#statusCode": [
+                      {
+                        "@value": ""
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": ""
+                      }
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/returns/resp/payload/application%2Fprotobuf",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/core#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/protobuf"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/returns/resp/payload/application%2Fprotobuf/shape/HelloReply",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "HelloReply"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "HelloReply"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#sources": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map",
+                                "@type": [
+                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map/synthesized-field/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "http://a.ml/vocabularies/document#link-target"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "true"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map/lexical/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/returns/resp/payload/application%2Fprotobuf/shape/HelloReply"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "[(15,2)-(15,54)]"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#operationId": [
+                  {
+                    "@value": "SayHello1"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/post/SayHello1"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(15,2)-(15,54)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Operation",
+                  "http://a.ml/vocabularies/core#Operation",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#method": [
+                  {
+                    "@value": "publish"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "SayHello2"
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#expects": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/expects/request",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Request",
+                      "http://a.ml/vocabularies/core#Request",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/expects/request/payload/application%2Fgrpc",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/core#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/grpc",
+                            "__apicResolved": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/expects/request/payload/application%2Fgrpc/shape/HelloRequest",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement",
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": ".helloworld.HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#sources": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map",
+                                "@type": [
+                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/expects/request/payload/application%2Fgrpc/shape/HelloRequest/source-map/synthesized-field/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "http://a.ml/vocabularies/document#link-target"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "true"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map/lexical/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "[(22,0)-(25,1)]",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#declared-element": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map/declared-element/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#property": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name",
+                                "@type": [
+                                  "http://www.w3.org/ns/shacl#PropertyShape",
+                                  "http://www.w3.org/ns/shacl#Shape",
+                                  "http://a.ml/vocabularies/shapes#Shape",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/shapes#range": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/shapes#ArrayShape",
+                                      "http://a.ml/vocabularies/shapes#AnyShape",
+                                      "http://www.w3.org/ns/shacl#Shape",
+                                      "http://a.ml/vocabularies/shapes#Shape",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/shapes#items": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                                          "http://a.ml/vocabularies/shapes#AnyShape",
+                                          "http://www.w3.org/ns/shacl#Shape",
+                                          "http://a.ml/vocabularies/shapes#Shape",
+                                          "http://a.ml/vocabularies/document#DomainElement"
+                                        ],
+                                        "http://www.w3.org/ns/shacl#datatype": [
+                                          {
+                                            "@id": "http://www.w3.org/2001/XMLSchema#string",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar/source-map",
+                                            "@type": [
+                                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                              {
+                                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar/source-map/lexical/element_0",
+                                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                                  {
+                                                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar",
+                                                    "__apicResolved": true
+                                                  }
+                                                ],
+                                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                                  {
+                                                    "@value": "[(23,11)-(23,17)]",
+                                                    "__apicResolved": true
+                                                  }
+                                                ],
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/source-map",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/source-map/lexical/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "[(23,2)-(23,27)]",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                                  {
+                                    "@value": 1,
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#name": [
+                                  {
+                                    "@value": "name",
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/source-map/lexical/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "[(23,2)-(23,27)]",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              },
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus",
+                                "@type": [
+                                  "http://www.w3.org/ns/shacl#PropertyShape",
+                                  "http://www.w3.org/ns/shacl#Shape",
+                                  "http://a.ml/vocabularies/shapes#Shape",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/shapes#range": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus",
+                                    "@type": [
+                                      "http://www.w3.org/ns/shacl#NodeShape",
+                                      "http://a.ml/vocabularies/shapes#AnyShape",
+                                      "http://www.w3.org/ns/shacl#Shape",
+                                      "http://a.ml/vocabularies/shapes#Shape",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/document#link-target": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document#link-label": [
+                                      {
+                                        "@value": "library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://www.w3.org/ns/shacl#name": [
+                                      {
+                                        "@value": "library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map/synthesized-field/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "http://a.ml/vocabularies/document#link-target",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "true",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map/lexical/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "[(24,2)-(24,15)]",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                                  {
+                                    "@value": 2,
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#name": [
+                                  {
+                                    "@value": "wadus",
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/source-map/lexical/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "[(24,2)-(24,26)]",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "__apicResolved": true
+                          }
+                        ],
+                        "__apicResolved": true
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#returns": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/returns/resp/",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Response",
+                      "http://a.ml/vocabularies/core#Response",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#statusCode": [
+                      {
+                        "@value": ""
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": ""
+                      }
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/returns/resp/payload/application%2Fprotobuf",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/core#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/protobuf"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/returns/resp/payload/application%2Fprotobuf/shape/HelloReply",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "HelloReply"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "HelloReply"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#sources": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map",
+                                "@type": [
+                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map/synthesized-field/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "http://a.ml/vocabularies/document#link-target"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "true"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map/lexical/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/returns/resp/payload/application%2Fprotobuf/shape/HelloReply"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "[(16,2)-(16,61)]"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#operationId": [
+                  {
+                    "@value": "SayHello2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/publish/SayHello2"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(16,2)-(16,61)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Operation",
+                  "http://a.ml/vocabularies/core#Operation",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#method": [
+                  {
+                    "@value": "subscribe"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "SayHello3"
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#expects": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/expects/request",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Request",
+                      "http://a.ml/vocabularies/core#Request",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/expects/request/payload/application%2Fgrpc",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/core#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/grpc",
+                            "__apicResolved": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/expects/request/payload/application%2Fgrpc/shape/HelloRequest",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement",
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": ".helloworld.HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#sources": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map",
+                                "@type": [
+                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/expects/request/payload/application%2Fgrpc/shape/HelloRequest/source-map/synthesized-field/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "http://a.ml/vocabularies/document#link-target"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "true"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map/lexical/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "[(22,0)-(25,1)]",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#declared-element": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map/declared-element/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#property": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name",
+                                "@type": [
+                                  "http://www.w3.org/ns/shacl#PropertyShape",
+                                  "http://www.w3.org/ns/shacl#Shape",
+                                  "http://a.ml/vocabularies/shapes#Shape",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/shapes#range": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/shapes#ArrayShape",
+                                      "http://a.ml/vocabularies/shapes#AnyShape",
+                                      "http://www.w3.org/ns/shacl#Shape",
+                                      "http://a.ml/vocabularies/shapes#Shape",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/shapes#items": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                                          "http://a.ml/vocabularies/shapes#AnyShape",
+                                          "http://www.w3.org/ns/shacl#Shape",
+                                          "http://a.ml/vocabularies/shapes#Shape",
+                                          "http://a.ml/vocabularies/document#DomainElement"
+                                        ],
+                                        "http://www.w3.org/ns/shacl#datatype": [
+                                          {
+                                            "@id": "http://www.w3.org/2001/XMLSchema#string",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar/source-map",
+                                            "@type": [
+                                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                              {
+                                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar/source-map/lexical/element_0",
+                                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                                  {
+                                                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar",
+                                                    "__apicResolved": true
+                                                  }
+                                                ],
+                                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                                  {
+                                                    "@value": "[(23,11)-(23,17)]",
+                                                    "__apicResolved": true
+                                                  }
+                                                ],
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/source-map",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/source-map/lexical/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "[(23,2)-(23,27)]",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                                  {
+                                    "@value": 1,
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#name": [
+                                  {
+                                    "@value": "name",
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/source-map/lexical/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "[(23,2)-(23,27)]",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              },
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus",
+                                "@type": [
+                                  "http://www.w3.org/ns/shacl#PropertyShape",
+                                  "http://www.w3.org/ns/shacl#Shape",
+                                  "http://a.ml/vocabularies/shapes#Shape",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/shapes#range": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus",
+                                    "@type": [
+                                      "http://www.w3.org/ns/shacl#NodeShape",
+                                      "http://a.ml/vocabularies/shapes#AnyShape",
+                                      "http://www.w3.org/ns/shacl#Shape",
+                                      "http://a.ml/vocabularies/shapes#Shape",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/document#link-target": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document#link-label": [
+                                      {
+                                        "@value": "library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://www.w3.org/ns/shacl#name": [
+                                      {
+                                        "@value": "library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map/synthesized-field/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "http://a.ml/vocabularies/document#link-target",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "true",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map/lexical/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "[(24,2)-(24,15)]",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                                  {
+                                    "@value": 2,
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#name": [
+                                  {
+                                    "@value": "wadus",
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/source-map/lexical/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "[(24,2)-(24,26)]",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "__apicResolved": true
+                          }
+                        ],
+                        "__apicResolved": true
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#returns": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/returns/resp/",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Response",
+                      "http://a.ml/vocabularies/core#Response",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#statusCode": [
+                      {
+                        "@value": ""
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": ""
+                      }
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/returns/resp/payload/application%2Fprotobuf",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/core#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/protobuf"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/returns/resp/payload/application%2Fprotobuf/shape/HelloReply",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "HelloReply"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "HelloReply"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#sources": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map",
+                                "@type": [
+                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map/synthesized-field/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "http://a.ml/vocabularies/document#link-target"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "true"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map/lexical/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/returns/resp/payload/application%2Fprotobuf/shape/HelloReply"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "[(17,2)-(17,61)]"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#operationId": [
+                  {
+                    "@value": "SayHello3"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/subscribe/SayHello3"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(17,2)-(17,61)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Operation",
+                  "http://a.ml/vocabularies/core#Operation",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#method": [
+                  {
+                    "@value": "pubsub"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "SayHello4"
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#expects": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/expects/request",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Request",
+                      "http://a.ml/vocabularies/core#Request",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/expects/request/payload/application%2Fgrpc",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/core#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/grpc",
+                            "__apicResolved": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/expects/request/payload/application%2Fgrpc/shape/HelloRequest",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement",
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": ".helloworld.HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#sources": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map",
+                                "@type": [
+                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/expects/request/payload/application%2Fgrpc/shape/HelloRequest/source-map/synthesized-field/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "http://a.ml/vocabularies/document#link-target"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "true"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map/lexical/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "[(22,0)-(25,1)]",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#declared-element": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map/declared-element/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#property": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name",
+                                "@type": [
+                                  "http://www.w3.org/ns/shacl#PropertyShape",
+                                  "http://www.w3.org/ns/shacl#Shape",
+                                  "http://a.ml/vocabularies/shapes#Shape",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/shapes#range": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/shapes#ArrayShape",
+                                      "http://a.ml/vocabularies/shapes#AnyShape",
+                                      "http://www.w3.org/ns/shacl#Shape",
+                                      "http://a.ml/vocabularies/shapes#Shape",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/shapes#items": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                                          "http://a.ml/vocabularies/shapes#AnyShape",
+                                          "http://www.w3.org/ns/shacl#Shape",
+                                          "http://a.ml/vocabularies/shapes#Shape",
+                                          "http://a.ml/vocabularies/document#DomainElement"
+                                        ],
+                                        "http://www.w3.org/ns/shacl#datatype": [
+                                          {
+                                            "@id": "http://www.w3.org/2001/XMLSchema#string",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar/source-map",
+                                            "@type": [
+                                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                              {
+                                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar/source-map/lexical/element_0",
+                                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                                  {
+                                                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar",
+                                                    "__apicResolved": true
+                                                  }
+                                                ],
+                                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                                  {
+                                                    "@value": "[(23,11)-(23,17)]",
+                                                    "__apicResolved": true
+                                                  }
+                                                ],
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/source-map",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/source-map/lexical/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "[(23,2)-(23,27)]",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                                  {
+                                    "@value": 1,
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#name": [
+                                  {
+                                    "@value": "name",
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/source-map/lexical/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "[(23,2)-(23,27)]",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              },
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus",
+                                "@type": [
+                                  "http://www.w3.org/ns/shacl#PropertyShape",
+                                  "http://www.w3.org/ns/shacl#Shape",
+                                  "http://a.ml/vocabularies/shapes#Shape",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/shapes#range": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus",
+                                    "@type": [
+                                      "http://www.w3.org/ns/shacl#NodeShape",
+                                      "http://a.ml/vocabularies/shapes#AnyShape",
+                                      "http://www.w3.org/ns/shacl#Shape",
+                                      "http://a.ml/vocabularies/shapes#Shape",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/document#link-target": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document#link-label": [
+                                      {
+                                        "@value": "library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://www.w3.org/ns/shacl#name": [
+                                      {
+                                        "@value": "library.Wadus",
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map",
+                                        "@type": [
+                                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map/synthesized-field/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "http://a.ml/vocabularies/document#link-target",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "true",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                          {
+                                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map/lexical/element_0",
+                                            "http://a.ml/vocabularies/document-source-maps#element": [
+                                              {
+                                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "http://a.ml/vocabularies/document-source-maps#value": [
+                                              {
+                                                "@value": "[(24,2)-(24,15)]",
+                                                "__apicResolved": true
+                                              }
+                                            ],
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                                  {
+                                    "@value": 2,
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#name": [
+                                  {
+                                    "@value": "wadus",
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/source-map/lexical/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "[(24,2)-(24,26)]",
+                                            "__apicResolved": true
+                                          }
+                                        ],
+                                        "__apicResolved": true
+                                      }
+                                    ],
+                                    "__apicResolved": true
+                                  }
+                                ],
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "HelloRequest",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "__apicResolved": true
+                          }
+                        ],
+                        "__apicResolved": true
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#returns": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/returns/resp/",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Response",
+                      "http://a.ml/vocabularies/core#Response",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#statusCode": [
+                      {
+                        "@value": ""
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": ""
+                      }
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/returns/resp/payload/application%2Fprotobuf",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/core#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/protobuf"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/returns/resp/payload/application%2Fprotobuf/shape/HelloReply",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "HelloReply"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "HelloReply"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#sources": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map",
+                                "@type": [
+                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map/synthesized-field/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "http://a.ml/vocabularies/document#link-target"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "true"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/returns/resp/payload/application%2Fprotobuf/shape/HelloReply/source-map/lexical/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/returns/resp/payload/application%2Fprotobuf/shape/HelloReply"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "[(18,2)-(18,68)]"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#operationId": [
+                  {
+                    "@value": "SayHello4"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/supportedOperation/pubsub/SayHello4"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(18,2)-(18,68)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/endpoint/Greeter"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(13,0)-(19,1)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/definedBy": {
+          "http://a.ml/vocabularies/core#extensionName": [
+            {
+              "@value": "java_multiple_files"
+            }
+          ],
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/data-node",
+          "@type": [
+            "http://a.ml/vocabularies/data#Scalar",
+            "http://a.ml/vocabularies/data#Node",
+            "http://a.ml/vocabularies/document#DomainElement"
+          ],
+          "http://a.ml/vocabularies/data#value": [
+            {
+              "@value": "true"
+            }
+          ],
+          "http://www.w3.org/ns/shacl#datatype": [
+            {
+              "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+            }
+          ],
+          "http://a.ml/vocabularies/document-source-maps#sources": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/data-node/source-map",
+              "@type": [
+                "http://a.ml/vocabularies/document-source-maps#SourceMap"
+              ],
+              "http://a.ml/vocabularies/document-source-maps#lexical": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/data-node/source-map/lexical/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/data-node"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(3,29)-(3,33)]"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_1/definedBy": {
+          "http://a.ml/vocabularies/core#extensionName": [
+            {
+              "@value": "java_package"
+            }
+          ],
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_1/data-node",
+          "@type": [
+            "http://a.ml/vocabularies/data#Scalar",
+            "http://a.ml/vocabularies/data#Node",
+            "http://a.ml/vocabularies/document#DomainElement"
+          ],
+          "http://a.ml/vocabularies/data#value": [
+            {
+              "@value": "io.grpc.examples.helloworld"
+            }
+          ],
+          "http://www.w3.org/ns/shacl#datatype": [
+            {
+              "@id": "http://www.w3.org/2001/XMLSchema#string"
+            }
+          ],
+          "http://a.ml/vocabularies/document-source-maps#sources": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_1/data-node/source-map",
+              "@type": [
+                "http://a.ml/vocabularies/document-source-maps#SourceMap"
+              ],
+              "http://a.ml/vocabularies/document-source-maps#lexical": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_1/data-node/source-map/lexical/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_1/data-node"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(4,22)-(4,51)]"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_2/definedBy": {
+          "http://a.ml/vocabularies/core#extensionName": [
+            {
+              "@value": "java_outer_classname"
+            }
+          ],
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_2/data-node",
+          "@type": [
+            "http://a.ml/vocabularies/data#Scalar",
+            "http://a.ml/vocabularies/data#Node",
+            "http://a.ml/vocabularies/document#DomainElement"
+          ],
+          "http://a.ml/vocabularies/data#value": [
+            {
+              "@value": "HelloWorldProto"
+            }
+          ],
+          "http://www.w3.org/ns/shacl#datatype": [
+            {
+              "@id": "http://www.w3.org/2001/XMLSchema#string"
+            }
+          ],
+          "http://a.ml/vocabularies/document-source-maps#sources": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_2/data-node/source-map",
+              "@type": [
+                "http://a.ml/vocabularies/document-source-maps#SourceMap"
+              ],
+              "http://a.ml/vocabularies/document-source-maps#lexical": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_2/data-node/source-map/lexical/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_2/data-node"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(5,30)-(5,47)]"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_3/definedBy": {
+          "http://a.ml/vocabularies/core#extensionName": [
+            {
+              "@value": "objc_class_prefix"
+            }
+          ],
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_3/data-node",
+          "@type": [
+            "http://a.ml/vocabularies/data#Scalar",
+            "http://a.ml/vocabularies/data#Node",
+            "http://a.ml/vocabularies/document#DomainElement"
+          ],
+          "http://a.ml/vocabularies/data#value": [
+            {
+              "@value": "HLW"
+            }
+          ],
+          "http://www.w3.org/ns/shacl#datatype": [
+            {
+              "@id": "http://www.w3.org/2001/XMLSchema#string"
+            }
+          ],
+          "http://a.ml/vocabularies/document-source-maps#sources": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_3/data-node/source-map",
+              "@type": [
+                "http://a.ml/vocabularies/document-source-maps#SourceMap"
+              ],
+              "http://a.ml/vocabularies/document-source-maps#lexical": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_3/data-node/source-map/lexical/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_3/data-node"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(6,27)-(6,32)]"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "http://a.ml/vocabularies/document#customDomainProperties": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/definedBy"
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_1/definedBy"
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_2/definedBy"
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/customDomainProperties/_3/definedBy"
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/web-api"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(1,0)-(68,1)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document#package": [
+      {
+        "@value": "helloworld"
+      }
+    ],
+    "http://a.ml/vocabularies/document#processingData": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/BaseUnitProcessingData",
+        "@type": [
+          "http://a.ml/vocabularies/document#APIContractProcessingData"
+        ],
+        "http://a.ml/vocabularies/apiContract#modelVersion": [
+          {
+            "@value": "3.11.0"
+          }
+        ],
+        "http://a.ml/vocabularies/document#sourceSpec": [
+          {
+            "@value": "Grpc"
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#references": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0",
+        "@type": [
+          "http://a.ml/vocabularies/document#Document",
+          "http://a.ml/vocabularies/document#Fragment",
+          "http://a.ml/vocabularies/document#Module",
+          "http://a.ml/vocabularies/document#Unit"
+        ],
+        "http://a.ml/vocabularies/document#encodes": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/web-api",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#WebAPI",
+              "http://a.ml/vocabularies/apiContract#API",
+              "http://a.ml/vocabularies/document#RootDomainElement",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "library"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#endpoint": [],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/web-api/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/web-api/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/web-api"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(1,0)-(7,1)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#declares": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message/array/default-array",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ArrayShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/shapes#items": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message/array/default-array/scalar/default-scalar",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message/array/default-array/scalar/default-scalar/source-map",
+                            "@type": [
+                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#lexical": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message/array/default-array/scalar/default-scalar/source-map/lexical/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message/array/default-array/scalar/default-scalar"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "[(6,11)-(6,17)]"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message/array/default-array/source-map",
+                        "@type": [
+                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message/array/default-array/source-map/lexical/element_0",
+                            "http://a.ml/vocabularies/document-source-maps#element": [
+                              {
+                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message/array/default-array"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#value": [
+                              {
+                                "@value": "[(6,2)-(6,30)]"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                  {
+                    "@value": 2
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "message"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/property/property/message"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(6,2)-(6,30)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": ".library.Wadus"
+              }
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "Wadus"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(5,0)-(7,1)]"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#declared-element": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus/source-map/declared-element/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": ""
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#references": [],
+        "http://a.ml/vocabularies/document#root": [
+          {
+            "@value": false
+          }
+        ],
+        "http://a.ml/vocabularies/document#package": [
+          {
+            "@value": "library"
+          }
+        ],
+        "http://a.ml/vocabularies/document#processingData": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/BaseUnitProcessingData",
+            "@type": [
+              "http://a.ml/vocabularies/document#APIContractProcessingData"
+            ],
+            "http://a.ml/vocabularies/apiContract#modelVersion": [
+              {
+                "@value": "3.11.0"
+              }
+            ],
+            "http://a.ml/vocabularies/document#sourceSpec": [
+              {
+                "@value": "Grpc"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#declares": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus",
+        "@type": [
+          "http://a.ml/vocabularies/shapes#ScalarShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": ".helloworld.Corpus"
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "Corpus"
+          }
+        ],
+        "http://www.w3.org/ns/shacl#in": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/list",
+            "@type": "http://www.w3.org/2000/01/rdf-schema#Seq",
+            "http://www.w3.org/2000/01/rdf-schema#_1": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/in/data-node",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "UNIVERSAL"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/in/data-node/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/in/data-node/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/in/data-node"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(45,2)-(45,11)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/shapes#serializationSchema": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/shape/default-node",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/shape/default-node/property/property/UNIVERSAL",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "UNIVERSAL"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/shape/default-node/property/property/UNIVERSAL/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/shape/default-node/property/property/UNIVERSAL/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/shape/default-node/property/property/UNIVERSAL"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(45,2)-(45,16)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/shape/default-node/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/shape/default-node/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/shape/default-node"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(44,0)-(46,1)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(44,0)-(46,1)]"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#declared-element": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus/source-map/declared-element/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.Corpus"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fa",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fa/scalar/default-scalar",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fa/scalar/default-scalar/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fa/scalar/default-scalar/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fa/scalar/default-scalar"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(30,4)-(30,10)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "fa"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fa/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fa/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fa"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(30,4)-(30,18)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fb",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fb/shape/default-node",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/document#link-target": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#link-label": [
+                  {
+                    "@value": "NestedMessage2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fb/shape/default-node/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fb/shape/default-node/source-map/synthesized-field/element_1",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/document#link-target"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fb/shape/default-node/source-map/synthesized-field/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/document#link-label"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fb/shape/default-node/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fb/shape/default-node"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(31,4)-(31,18)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 2
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "fb"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fb/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fb/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/property/property/fb"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(31,4)-(31,26)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": ".helloworld.SampleMessage.NestedMessage1"
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "NestedMessage1"
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(29,2)-(35,3)]"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#declared-element": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1/source-map/declared-element/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ArrayShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#items": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string",
+                        "__apicResolved": true
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar/source-map",
+                        "@type": [
+                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar/source-map/lexical/element_0",
+                            "http://a.ml/vocabularies/document-source-maps#element": [
+                              {
+                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/scalar/default-scalar",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#value": [
+                              {
+                                "@value": "[(23,11)-(23,17)]",
+                                "__apicResolved": true
+                              }
+                            ],
+                            "__apicResolved": true
+                          }
+                        ],
+                        "__apicResolved": true
+                      }
+                    ],
+                    "__apicResolved": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/array/default-array",
+                            "__apicResolved": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(23,2)-(23,27)]",
+                            "__apicResolved": true
+                          }
+                        ],
+                        "__apicResolved": true
+                      }
+                    ],
+                    "__apicResolved": true
+                  }
+                ],
+                "__apicResolved": true
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 1,
+                "__apicResolved": true
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "name",
+                "__apicResolved": true
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/name",
+                        "__apicResolved": true
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(23,2)-(23,27)]",
+                        "__apicResolved": true
+                      }
+                    ],
+                    "__apicResolved": true
+                  }
+                ],
+                "__apicResolved": true
+              }
+            ],
+            "__apicResolved": true
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/document#link-target": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/references/0/declares/shape/.library.Wadus",
+                    "__apicResolved": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#link-label": [
+                  {
+                    "@value": "library.Wadus",
+                    "__apicResolved": true
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "library.Wadus",
+                    "__apicResolved": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map/synthesized-field/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/document#link-target",
+                            "__apicResolved": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "true",
+                            "__apicResolved": true
+                          }
+                        ],
+                        "__apicResolved": true
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/shape/library.Wadus",
+                            "__apicResolved": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(24,2)-(24,15)]",
+                            "__apicResolved": true
+                          }
+                        ],
+                        "__apicResolved": true
+                      }
+                    ],
+                    "__apicResolved": true
+                  }
+                ],
+                "__apicResolved": true
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 2,
+                "__apicResolved": true
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "wadus",
+                "__apicResolved": true
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/property/property/wadus",
+                        "__apicResolved": true
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(24,2)-(24,26)]",
+                        "__apicResolved": true
+                      }
+                    ],
+                    "__apicResolved": true
+                  }
+                ],
+                "__apicResolved": true
+              }
+            ],
+            "__apicResolved": true
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": ".helloworld.HelloRequest",
+            "__apicResolved": true
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "HelloRequest",
+            "__apicResolved": true
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                    "__apicResolved": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(22,0)-(25,1)]",
+                    "__apicResolved": true
+                  }
+                ],
+                "__apicResolved": true
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#declared-element": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest/source-map/declared-element/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest",
+                    "__apicResolved": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "",
+                    "__apicResolved": true
+                  }
+                ],
+                "__apicResolved": true
+              }
+            ],
+            "__apicResolved": true
+          }
+        ],
+        "__apicResolved": true
+      },
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/query",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/query/scalar/default-scalar",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/query/scalar/default-scalar/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/query/scalar/default-scalar/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/query/scalar/default-scalar"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(49,2)-(49,8)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "query"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/query/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/query/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/query"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(49,2)-(49,19)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/page_number",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/page_number/scalar/default-scalar",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#format": [
+                  {
+                    "@value": "int32"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/page_number/scalar/default-scalar/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/page_number/scalar/default-scalar/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/page_number/scalar/default-scalar"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(50,2)-(50,7)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 2
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "page_number"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/page_number/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/page_number/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/page_number"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(50,2)-(50,24)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/result_per_page",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/result_per_page/scalar/default-scalar",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#format": [
+                  {
+                    "@value": "int32"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/result_per_page/scalar/default-scalar/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/result_per_page/scalar/default-scalar/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/result_per_page/scalar/default-scalar"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(51,2)-(51,7)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 3
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "result_per_page"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/result_per_page/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/result_per_page/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/result_per_page"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(51,2)-(51,28)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/corpus",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/corpus/scalar/Corpus",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/document#link-target": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#link-label": [
+                  {
+                    "@value": "Corpus"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "Corpus"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/corpus/scalar/Corpus/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/corpus/scalar/Corpus/source-map/synthesized-field/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/document#link-target"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/corpus/scalar/Corpus/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/corpus/scalar/Corpus"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(61,2)-(61,8)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 4
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "corpus"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/corpus/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/corpus/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/property/property/corpus"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(61,2)-(61,20)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": ".helloworld.SearchRequest"
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "SearchRequest"
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(48,0)-(62,1)]"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#declared-element": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest/source-map/declared-element/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/property/property/fa",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/property/property/fa/scalar/default-scalar",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/property/property/fa/scalar/default-scalar/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/property/property/fa/scalar/default-scalar/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/property/property/fa/scalar/default-scalar"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(33,6)-(33,12)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "fa"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/property/property/fa/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/property/property/fa/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/property/property/fa"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(33,6)-(33,20)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": ".helloworld.SampleMessage.NestedMessage1.NestedMessage2"
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "NestedMessage2"
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(32,4)-(34,5)]"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#declared-element": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2/source-map/declared-element/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#additionalPropertiesKeySchema": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/scalar/default-scalar",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/scalar/default-scalar/source-map",
+                        "@type": [
+                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/scalar/default-scalar/source-map/lexical/element_0",
+                            "http://a.ml/vocabularies/document-source-maps#element": [
+                              {
+                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/scalar/default-scalar"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#value": [
+                              {
+                                "@value": "[(28,6)-(28,12)]"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#additionalPropertiesSchema": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/shape/default-node",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#NodeShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/document#link-target": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SearchRequest"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document#link-label": [
+                      {
+                        "@value": "SearchRequest"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/shape/default-node/source-map",
+                        "@type": [
+                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/shape/default-node/source-map/synthesized-field/element_1",
+                            "http://a.ml/vocabularies/document-source-maps#element": [
+                              {
+                                "@value": "http://a.ml/vocabularies/document#link-target"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#value": [
+                              {
+                                "@value": "true"
+                              }
+                            ]
+                          },
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/shape/default-node/source-map/synthesized-field/element_0",
+                            "http://a.ml/vocabularies/document-source-maps#element": [
+                              {
+                                "@value": "http://a.ml/vocabularies/document#link-label"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#value": [
+                              {
+                                "@value": "true"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/shape/default-node/source-map/lexical/element_0",
+                            "http://a.ml/vocabularies/document-source-maps#element": [
+                              {
+                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/shape/default-node"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#value": [
+                              {
+                                "@value": "[(28,14)-(28,27)]"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/shape/default-node"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(28,2)-(28,42)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 3
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "searches"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/searches"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(28,2)-(28,42)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fc",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fc/shape/NestedMessage1.NestedMessage2",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/document#link-target": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage.NestedMessage1.NestedMessage2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#link-label": [
+                  {
+                    "@value": "NestedMessage1.NestedMessage2"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "NestedMessage1.NestedMessage2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fc/shape/NestedMessage1.NestedMessage2/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fc/shape/NestedMessage1.NestedMessage2/source-map/synthesized-field/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/document#link-target"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fc/shape/NestedMessage1.NestedMessage2/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fc/shape/NestedMessage1.NestedMessage2"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(36,2)-(36,31)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 10
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "fc"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fc/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fc/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fc"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(36,2)-(36,40)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fd",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fd/shape/.helloworld.HelloRequest",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/document#link-target": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#link-label": [
+                  {
+                    "@value": ".helloworld.HelloRequest"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": ".helloworld.HelloRequest"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fd/shape/.helloworld.HelloRequest/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fd/shape/.helloworld.HelloRequest/source-map/synthesized-field/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/document#link-target"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fd/shape/.helloworld.HelloRequest/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fd/shape/.helloworld.HelloRequest"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(37,2)-(37,26)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 11
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "fd"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fd/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fd/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/property/property/fd"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(37,2)-(37,35)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": ".helloworld.SampleMessage"
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "SampleMessage"
+          }
+        ],
+        "http://www.w3.org/ns/shacl#and": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof",
+            "@type": [
+              "http://a.ml/vocabularies/shapes#UnionShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#anyOf": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#property": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node/property/property/name",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node/property/property/name/scalar/default-scalar",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node/property/property/name/scalar/default-scalar/source-map",
+                            "@type": [
+                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#lexical": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node/property/property/name/scalar/default-scalar/source-map/lexical/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node/property/property/name/scalar/default-scalar"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "[(39,4)-(39,10)]"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#serializationOrder": [
+                      {
+                        "@value": 4
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node/property/property/name/source-map",
+                        "@type": [
+                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node/property/property/name/source-map/lexical/element_0",
+                            "http://a.ml/vocabularies/document-source-maps#element": [
+                              {
+                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node/property/property/name"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#value": [
+                              {
+                                "@value": "[(39,4)-(39,20)]"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(39,4)-(39,20)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#property": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/property/property/sub_message",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/property/property/sub_message/shape/HelloRequest",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#NodeShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/document#link-target": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloRequest"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document#link-label": [
+                          {
+                            "@value": "HelloRequest"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "HelloRequest"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/property/property/sub_message/shape/HelloRequest/source-map",
+                            "@type": [
+                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/property/property/sub_message/shape/HelloRequest/source-map/synthesized-field/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "http://a.ml/vocabularies/document#link-target"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "true"
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#lexical": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/property/property/sub_message/shape/HelloRequest/source-map/lexical/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/property/property/sub_message/shape/HelloRequest"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "[(40,4)-(40,16)]"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#serializationOrder": [
+                      {
+                        "@value": 9
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "sub_message"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/property/property/sub_message/source-map",
+                        "@type": [
+                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/property/property/sub_message/source-map/lexical/element_0",
+                            "http://a.ml/vocabularies/document-source-maps#element": [
+                              {
+                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/property/property/sub_message"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#value": [
+                              {
+                                "@value": "[(40,4)-(40,33)]"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/anyOf/shape/default-node_10"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(40,4)-(40,33)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "test_oneof"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/and/union/test_oneof"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(38,2)-(41,3)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(27,0)-(42,1)]"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#declared-element": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage/source-map/declared-element/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.SampleMessage"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus",
+        "@type": [
+          "http://a.ml/vocabularies/shapes#ScalarShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": ".helloworld.SearchRequest.Corpus"
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "Corpus"
+          }
+        ],
+        "http://www.w3.org/ns/shacl#in": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/list",
+            "@type": "http://www.w3.org/2000/01/rdf-schema#Seq",
+            "http://www.w3.org/2000/01/rdf-schema#_1": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "UNIVERSAL"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(53,4)-(53,13)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#_2": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_4",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "WEB"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_4/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_4/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_4"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(54,4)-(54,7)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#_3": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_5",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "IMAGES"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_5/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_5/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_5"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(55,4)-(55,10)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#_4": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_6",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "LOCAL"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_6/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_6/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_6"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(56,4)-(56,9)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#_5": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_7",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "NEWS"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_7/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_7/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_7"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(57,4)-(57,8)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#_6": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_8",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "PRODUCTS"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_8/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_8/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_8"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(58,4)-(58,12)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#_7": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_9",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "VIDEO"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_9/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_9/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/in/data-node_9"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(59,4)-(59,9)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/shapes#serializationSchema": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/UNIVERSAL",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "UNIVERSAL"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/UNIVERSAL/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/UNIVERSAL/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/UNIVERSAL"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(53,4)-(53,18)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/WEB",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "WEB"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/WEB/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/WEB/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/WEB"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(54,4)-(54,12)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/IMAGES",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                  {
+                    "@value": 2
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "IMAGES"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/IMAGES/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/IMAGES/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/IMAGES"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(55,4)-(55,15)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/LOCAL",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                  {
+                    "@value": 3
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "LOCAL"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/LOCAL/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/LOCAL/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/LOCAL"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(56,4)-(56,14)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/NEWS",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                  {
+                    "@value": 4
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "NEWS"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/NEWS/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/NEWS/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/NEWS"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(57,4)-(57,13)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/PRODUCTS",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                  {
+                    "@value": 5
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "PRODUCTS"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/PRODUCTS/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/PRODUCTS/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/PRODUCTS"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(58,4)-(58,17)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/VIDEO",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#serializationOrder": [
+                  {
+                    "@value": 6
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "VIDEO"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/VIDEO/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/VIDEO/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/property/property/VIDEO"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(59,4)-(59,14)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/shape/default-node"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(52,2)-(60,3)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(52,2)-(60,3)]"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#declared-element": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus/source-map/declared-element/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/message",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/message/scalar/default-scalar",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/message/scalar/default-scalar/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/message/scalar/default-scalar/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/message/scalar/default-scalar"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(66,2)-(66,8)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "message"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/message/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/message/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/message"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(66,2)-(66,21)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/other",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/other/scalar/SearchRequest.Corpus",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/document#link-target": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/scalar/.helloworld.SearchRequest.Corpus"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#link-label": [
+                  {
+                    "@value": "SearchRequest.Corpus"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "SearchRequest.Corpus"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/other/scalar/SearchRequest.Corpus/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/other/scalar/SearchRequest.Corpus/source-map/synthesized-field/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/document#link-target"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/other/scalar/SearchRequest.Corpus/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/other/scalar/SearchRequest.Corpus"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(67,2)-(67,22)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#serializationOrder": [
+              {
+                "@value": 2
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "other"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/other/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/other/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/property/property/other"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(67,2)-(67,33)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": ".helloworld.HelloReply"
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "HelloReply"
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(65,0)-(68,1)]"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#declared-element": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply/source-map/declared-element/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/upanddown/grpc/simple.proto#/declares/shape/.helloworld.HelloReply"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,10 @@
         "@polymer/app-layout": "^3.1.0",
         "@polymer/iron-media-query": "^3.0.0",
         "@polymer/paper-toast": "^3.0.0",
+        "grpc-web": "^1.5.0",
         "lit-element": "^2.3.1",
-        "lit-html": "^1.2.1"
+        "lit-html": "^1.2.1",
+        "protobufjs": "^7.5.4"
       },
       "devDependencies": {
         "@anypoint-web-components/anypoint-dropdown": "^1.0.1",
@@ -6540,6 +6542,70 @@
         "prismjs": "^1.11.0"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rdfjs/types": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
@@ -7096,8 +7162,7 @@
     "node_modules/@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -13133,6 +13198,12 @@
         "node": ">=4.x"
       }
     },
+    "node_modules/grpc-web": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.5.0.tgz",
+      "integrity": "sha512-y1tS3BBIoiVSzKTDF3Hm7E8hV2n7YY7pO0Uo7depfWJqKzWE+SKr0jvHNIJsJJYILQlpYShpi/DRJJMbosgDMQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -15766,6 +15837,12 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loupe": {
       "version": "2.3.6",
@@ -18599,6 +18676,30 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -28977,6 +29078,60 @@
         "prismjs": "^1.11.0"
       }
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "@rdfjs/types": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
@@ -29501,8 +29656,7 @@
     "@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -34265,6 +34419,11 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "grpc-web": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.5.0.tgz",
+      "integrity": "sha512-y1tS3BBIoiVSzKTDF3Hm7E8hV2n7YY7pO0Uo7depfWJqKzWE+SKr0jvHNIJsJJYILQlpYShpi/DRJJMbosgDMQ=="
+    },
     "hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -36280,6 +36439,11 @@
         "safe-stable-stringify": "^2.3.1",
         "triple-beam": "^1.3.0"
       }
+    },
+    "long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
     "loupe": {
       "version": "2.3.6",
@@ -38432,6 +38596,25 @@
       "requires": {
         "to-object-x": "^1.4.1",
         "to-property-key-x": "^2.0.1"
+      }
+    },
+    "protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
       }
     },
     "proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
     "@polymer/app-layout": "^3.1.0",
     "@polymer/iron-media-query": "^3.0.0",
     "@polymer/paper-toast": "^3.0.0",
+    "grpc-web": "^1.5.0",
     "lit-element": "^2.3.1",
-    "lit-html": "^1.2.1"
+    "lit-html": "^1.2.1",
+    "protobufjs": "^7.5.4"
   },
   "devDependencies": {
     "@anypoint-web-components/anypoint-dropdown": "^1.0.1",

--- a/src/ApiConsoleStyles.js
+++ b/src/ApiConsoleStyles.js
@@ -141,4 +141,63 @@ a.attribution {
   width: 24px;
   height: 24px;
   display: block;
+}
+
+.grpc-request-panel {
+  padding: 16px;
+  background-color: var(--api-console-grpc-panel-background-color, #f5f5f5);
+  border-radius: 4px;
+  margin: 16px;
+}
+
+.grpc-request-panel h3 {
+  margin: 0 0 16px 0;
+  font-size: var(--arc-font-title-font-size);
+  font-weight: var(--arc-font-title-font-weight);
+  letter-spacing: var(--arc-font-title-letter-spacing);
+  line-height: var(--arc-font-title-line-height);
+}
+
+.grpc-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.grpc-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.grpc-field label {
+  font-size: var(--arc-font-body1-font-size);
+  font-weight: var(--arc-font-body1-font-weight);
+  color: var(--api-console-grpc-label-color, rgba(0, 0, 0, 0.87));
+}
+
+.grpc-field input {
+  padding: 8px;
+  border: 1px solid var(--api-console-grpc-input-border-color, rgba(0, 0, 0, 0.12));
+  border-radius: 4px;
+  font-size: var(--arc-font-body1-font-size);
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.grpc-field input:focus {
+  border-color: var(--api-console-grpc-input-focus-color, #2196f3);
+}
+
+.grpc-nested-message {
+  padding: 16px;
+  background-color: var(--api-console-grpc-nested-background-color, rgba(0, 0, 0, 0.03));
+  border-radius: 4px;
+}
+
+.grpc-nested-message h4 {
+  margin: 0 0 12px 0;
+  font-size: var(--arc-font-subhead-font-size);
+  font-weight: var(--arc-font-subhead-font-weight);
+  color: var(--api-console-grpc-nested-title-color, rgba(0, 0, 0, 0.87));
 }`;


### PR DESCRIPTION
#### Summary 
- Introduced `example.proto` for gRPC service definition with `SayHello` method.
- Updated `package.json` and `package-lock.json` to include `grpc-web` and `protobufjs` dependencies.
- Enhanced `ApiConsole` to handle gRPC operations, including request schema extraction and dynamic message creation.
- Added styles for gRPC request panel in `ApiConsoleStyles.js`.
- Implemented form rendering for gRPC fields and handling of gRPC requests in the API console.

# Spike: gRPC Integration in API Console

## Objective
Evaluate the technical feasibility of integrating gRPC support into API Console, enabling visualization of gRPC API metadata (using JSON-LD generated by AMF) and testing operations (e.g., `Greeter.SayHello1`) via a "Try It" panel in the browser, while maintaining compatibility with REST/RAML.

## Context
API Console currently supports REST/RAML and YAML APIs used by MuleSoft products like Design Center and Exchange. This spike explores:
1. Parsing gRPC models in JSON-LD format (e.g., `grpc.json`, with service `Greeter`, methods `SayHello1`/`SayHello2`, and messages `HelloRequest`/`HelloReply`).
2. Implementing a gRPC-Web client for browser-based requests.
3. Setting up a gRPC-Web proxy to connect the UI to gRPC servers.
4. Generating a consistent UI for navigation and testing, based on JSON-LD.

## Proposed Architecture

### Main Components
```mermaid
graph TD
    A[API Console UI] -->|Parses| B[AMF JSON-LD Parser]
    A -->|Generates| C[gRPC Try Panel]
    C -->|Sends request| D[gRPC-Web Client]
    D -->|Translates HTTP/1.1 to HTTP/2| E[gRPC-Web Proxy]
    E -->|Native gRPC| F[gRPC Server]
    B -->|Extracts| G[JSON-LD Model: grpc.json]
    G -->|Converts to| H[Proto Schema]
    H -->|Used by| D
```

### Technology Stack
- **Frontend**: LitElement (API Console base).
- **gRPC Client**: `grpc-web` (for browser).
- **Schema Parsing**: `protobufjs` (to interpret JSON-LD and build messages).
- **Proxy**: `@grpc-web/proxy` (Node.js) or Envoy (production).
- **Server**: Node.js with `@grpc/grpc-js` (for local testing).
- **Dependencies**: `npm install grpc-web protobufjs @grpc-web/proxy @grpc/grpc-js`.

## Implementation

### 1. Detecting gRPC Operations
Detect if an operation is gRPC by checking the `mediaType` in the JSON-LD:
```javascript
_isGrpcOperation(selected, webApi) {
  const method = this._computeMethodModel(webApi, selected);
  const request = this._computePayload(method);
  const mediaType = this._getValue(request, this.ns.aml.vocabularies.core.mediaType);
  return mediaType === 'application/grpc';
}
```

### 2. Parsing JSON-LD for Schemas
Extract services, methods, and messages from JSON-LD to generate the UI:
```javascript
_getGrpcRequestSchema(selected, webApi) {
  const method = this._computeMethodModel(webApi, selected);
  const request = this._computePayload(method);
  const schema = this._getValue(request, this.ns.aml.vocabularies.shapes.schema);
  const properties = this._getValueArray(schema, 'property');
  
  return {
    name: this._getValue(schema, this.ns.aml.vocabularies.core.name), // e.g., "HelloRequest"
    fields: properties.map(prop => ({
      name: this._getValue(prop, this.ns.aml.vocabularies.core.name), // e.g., "name"
      type: this._getValue(prop, this.ns.aml.vocabularies.shapes.range), // e.g., string
      required: this._getValue(prop, this.ns.aml.vocabularies.shapes.minCount) > 0
    }))
  };
}
```

### 3. UI for the Try Panel
Add a panel with a form and a "Try gRPC Request" button:
```javascript
html`
  <div class="grpc-request-panel">
    <h3>gRPC Request: ${methodName}</h3>
    <div class="grpc-form">
      ${schema.fields.map(field => this._renderGrpcField(field))}
    </div>
    <anypoint-button @click="${this._handleGrpcRequest}">
      Try gRPC Request
    </anypoint-button>
  </div>
`;
```

### 4. gRPC-Web Client
Use `grpc-web` to send requests to the proxy:
```javascript
import { GrpcWebClientBase } from 'grpc-web';

async _handleGrpcRequest() {
  const client = new GrpcWebClientBase({
    format: 'text', // grpcwebtext for browser compatibility
    suppressCorsPreflight: true
  });
  const message = this._buildProtobufMessage(this.formData); // Convert form to protobuf
  try {
    const response = await client.rpcCall(
      'http://localhost:8080/helloworld.Greeter/SayHello1',
      message,
      {}, // Metadata
      null, // Call options
      () => {}
    );
    this._displayResponse(response); // Display in UI
  } catch (err) {
    this._displayError(err);
  }
}
```

### 5. gRPC-Web Proxy Configuration
The proxy is critical to translate gRPC-Web to native gRPC, as browsers do not support full HTTP/2. We use `@grpc-web/proxy` for local testing:
```javascript
const express = require('express');
const cors = require('cors');
const { createServer } = require('@grpc-web/proxy');

const app = express();
app.use(cors());
const proxy = createServer({
  upstream: 'http://localhost:50051', // gRPC server
  protoPath: './simple.proto', // Based on grpc.json
  binary: true
});
app.use('/', proxy);
app.listen(8080, () => console.log('gRPC-Web proxy on :8080'));
```

### 6. Local gRPC Server (for Testing)
Implemented a test server in Node.js to simulate `Greeter`:
```javascript
const grpc = require('@grpc/grpc-js');
const protoLoader = require('@grpc/proto-loader');
const packageDefinition = protoLoader.loadSync('simple.proto');
const helloworld = grpc.loadPackageDefinition(packageDefinition).helloworld;

function sayHello(call, callback) {
  const name = call.request.getName();
  callback(null, { message: `Hello ${name}! Wadus received.` });
}

const server = new grpc.Server();
server.addService(helloworld.Greeter.service, { SayHello1: sayHello, SayHello2: sayHello });
server.bindAsync('0.0.0.0:50051', grpc.ServerCredentials.createInsecure(), () => {
  server.start();
  console.log('gRPC server on :50051');
});
```

## Challenges and Considerations

### 1. Proxy Configuration
- **Need**: Browsers do not support native gRPC (HTTP/2 with trailers). A proxy (`@grpc-web/proxy` or Envoy) translates gRPC-Web to native gRPC.
- **Adoption by Other Teams**:
  - **Installable Library**: `@grpc-web/proxy` is an npm module, easy to share via an internal registry (e.g., `@mulesoft/grpc-web-proxy`).
  - **Alternative**: Envoy for production (configured via `envoy.yaml`, run with Docker).
  - **Recommendation**: Package the proxy as an npm module with a simple CLI (e.g., `setupGrpcWebProxy --port 8080 --upstream :50051`).

### 2. JSON-LD Parsing
- **Challenge**: The JSON-LD (`grpc.json`) contains services (`Greeter`), methods (`SayHello1`), and messages (`HelloRequest` with `name`, `wadus`). Parsing `shacl#property` and `shapes#range` recursively for nested messages and enums.
- **Solution**: Use `protobufjs` to convert JSON-LD to a dynamic protobuf schema, generating forms in the try panel.

### 3. RPC Types
- **Unary**: Implemented (e.g., `SayHello1`).
- **Streaming**: Pending; requires UI for handling streams (e.g., "send chunk" buttons, real-time logs).
- **Challenge**: Differentiate in the UI (icons for unary vs. streaming) and handle `grpc-web` callbacks.

### 4. Security
- **CORS**: Configured in the proxy (`cors` middleware).
- **TLS/SSL**: Insecure for local testing; production requires certificates.
- **Authentication**: Support for metadata (e.g., OAuth tokens) in `grpc-web`.

### 5. MuleSoft Compatibility
- **Integration with Design Center/Exchange**: Extend the AMF parser to map gRPC to RAML-like structures, enabling previews in Design Center.
- **Challenge**: Align with MuleSoft's asset model, treating gRPC services as "endpoints".

## Next Steps

### Phase 1: Fundamentals
1. [ ] Implement a robust JSON-LD to protobuf parser (handle oneof, enums).
2. [ ] Support unary calls in the try panel.
3. [ ] Document proxy setup (`@grpc-web/proxy`) for teams.

### Phase 2: Streaming and Features
1. [ ] Support streaming (client/server/bidirectional) in the UI.
2. [ ] Add metadata and headers in the try panel.
3. [ ] Implement cancellation and timeouts.

### Phase 3: UX and Adoption
1. [ ] Dedicated panel for responses and errors.
2. [ ] Autocomplete and form validation based on JSON-LD.
3. [ ] Publish `@mulesoft/grpc-web-proxy` as an internal npm module.
4. [ ] Guide for integration with Design Center/Exchange.

## Conclusions

### Feasibility
gRPC integration in API Console is **feasible** using:
- JSON-LD for metadata (parsed with `protobufjs`).
- `grpc-web` for browser requests.
- `@grpc-web/proxy` or Envoy to connect to gRPC servers.
- LitElement's modular architecture for REST compatibility.

### Recommendations
1. Prioritize unary calls for an MVP.
2. Standardize the proxy as an npm module for adoption.
3. Align with MuleSoft products via AMF mappings.
4. Use tools like `grpcui` for initial local testing.

### Risks
1. **Proxy Complexity**: Setup may be a barrier for teams unfamiliar with gRPC.
2. **Streaming UX**: Requires significant try panel changes.
3. **Maintenance**: Support for new gRPC-Web and AMF versions.
4. **Performance**: Parsing large JSON-LD and protobuf encoding in the browser.

## References
- [gRPC-Web GitHub](https://github.com/grpc/grpc-web)
- [Protobuf.js Documentation](https://github.com/protobufjs/protobuf.js)
- [AMF Documentation](https://a.ml/)
- [Envoy Proxy Docs](https://www.envoyproxy.io/docs/envoy/latest/)
- [gRPCui Tool](https://github.com/fullstorydev/grpcui)