### PR TITLE
Build/6.6.52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api-console",
-  "version": "6.6.51",
+  "version": "6.6.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api-console",
-      "version": "6.6.51",
+      "version": "6.6.52",
       "license": "CPAL-1.0",
       "dependencies": {
         "@advanced-rest-client/arc-icons": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-console",
   "description": "The API Console to automatically generate API documentation from RAML and OAS files.",
-  "version": "6.6.51",
+  "version": "6.6.52",
   "license": "CPAL-1.0",
   "main": "index.js",
   "module": "index.js",


### PR DESCRIPTION
Fix vuln https://nvd.nist.gov/vuln/detail/cve-2025-48050  
fixed in Dompurify >= 3.2.5