### PR TITLE
[@W-21530944] Release v6.6.63       

### DIFF
--- a/demo/themed/dark-theme.css
+++ b/demo/themed/dark-theme.css
@@ -120,13 +120,17 @@ html {
   --http-method-label-delete-background-color: var(--http-delete-color);
   --http-method-label-delete-color: #fff;
   --http-method-label-options-background-color: var(--http-options-color);
-  --http-method-label-options-background-color: #fff;
+  --http-method-label-options-color: #fff;
   --http-method-label-head-background-color: var(--http-head-color);
-  --http-method-label-head-background-color: #fff;
+  --http-method-label-head-color: #fff;
   --http-method-label-trace-background-color: var(--http-trace-color);
-  --http-method-label-trace-background-color: #fff;
+  --http-method-label-trace-color: #fff;
   --http-method-label-connect-background-color: var(--http-connect-color);
-  --http-method-label-connect-background-color: #fff;
+  --http-method-label-connect-color: #fff;
+  --http-method-label-publish-background-color: rgba(31, 157, 85, 0.74);
+  --http-method-label-publish-color: #fff;
+  --http-method-label-subscribe-background-color: rgba(52, 144, 220, 0.74);
+  --http-method-label-subscribe-color: #fff;
 }
 
 body {

--- a/demo/themed/dark.js
+++ b/demo/themed/dark.js
@@ -15,7 +15,8 @@ class ApicApplication extends DemoBase {
       ['google-drive-api', 'Google Drive API'],
       ['httpbin', 'HTTPbin API'],
       ['data-type-fragment', 'RAML data type fragment'],
-      ['demo-api', 'Demo API']
+      ['demo-api', 'Demo API'],
+      ['grpc-test', 'gRPC Test API']
     ];
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api-console",
-  "version": "6.6.62",
+  "version": "6.6.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api-console",
-      "version": "6.6.62",
+      "version": "6.6.63",
       "license": "CPAL-1.0",
       "dependencies": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
@@ -1403,9 +1403,9 @@
       }
     },
     "node_modules/@api-components/api-summary": {
-      "version": "4.6.18",
-      "resolved": "https://registry.npmjs.org/@api-components/api-summary/-/api-summary-4.6.18.tgz",
-      "integrity": "sha512-bTKGr541gk7XlrXC8HmktK3mgVGPB6g+efpf0U757lhEb6w8dzRENZ316nH8CcqPOoAWrqdS9THsnagWuKycTQ==",
+      "version": "4.6.19",
+      "resolved": "https://registry.npmjs.org/@api-components/api-summary/-/api-summary-4.6.19.tgz",
+      "integrity": "sha512-Uxc3RjCdvNdVNYn61nuq620MMuYmr6C33bCmLgr99jPb1cp5y1e7yLV563XAv9PZ9z9jPjBc6JM+HTIusjYtoA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-marked": "^1.1.2",
@@ -1422,9 +1422,9 @@
       }
     },
     "node_modules/@api-components/api-type-document": {
-      "version": "4.2.42",
-      "resolved": "https://registry.npmjs.org/@api-components/api-type-document/-/api-type-document-4.2.42.tgz",
-      "integrity": "sha512-nSMsTrlEMkpvtSToYOKQMkQL2psL0zE4fVX14VVR95CRVh/78t97n9zvxFitHkYQTwVxWU0ti/yG7OXIkmiV2Q==",
+      "version": "4.2.43",
+      "resolved": "https://registry.npmjs.org/@api-components/api-type-document/-/api-type-document-4.2.43.tgz",
+      "integrity": "sha512-nMcTMWxkw5lUNKT4Grldl8UglbTYkBKvZzIqjxYaWb3O7BuCYsk/00hKUe0nXi3pORash8A6FpmCVOAFFZHY5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-marked": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-console",
   "description": "The API Console to automatically generate API documentation from RAML and OAS files.",
-  "version": "6.6.62",
+  "version": "6.6.63",
   "license": "CPAL-1.0",
   "main": "index.js",
   "module": "index.js",


### PR DESCRIPTION
## Updated Components

  - @api-components/api-summary: 4.6.16 → 4.6.19
  - @api-components/api-type-document: 4.2.41 → 4.2.43

  ## Fixes

  ### api-summary v4.6.19
  - Fix gRPC navigation click on nested span elements (PR [#59](https://github.com/advanced-rest-client/api-summary/pull/59))
  - 

  ### api-type-document v4.2.43
  - Fix dark mode union/oneOf/anyOf button styling (PR [#98](https://github.com/advanced-rest-client/api-type-document/pull/98))

  ## Related

  - W-21530944: APIC Release 6.6.63(6.6.90)
  
  
  

https://github.com/user-attachments/assets/5f413f68-fe2b-4b50-9801-b53c49271602

