### PR TITLE
@W-22440070 chore: bump version to 6.6.64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api-console",
-  "version": "6.6.63",
+  "version": "6.6.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api-console",
-      "version": "6.6.63",
+      "version": "6.6.64",
       "license": "CPAL-1.0",
       "dependencies": {
         "@advanced-rest-client/arc-icons": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-console",
   "description": "The API Console to automatically generate API documentation from RAML and OAS files.",
-  "version": "6.6.63",
+  "version": "6.6.64",
   "license": "CPAL-1.0",
   "main": "index.js",
   "module": "index.js",


### PR DESCRIPTION
OSPO compliance release — no functional changes.

Includes:
- CODE_OF_CONDUCT.md (salesforce/oss-template)
- SECURITY.md (salesforce/oss-template)
- #ECCN:Open Source line in .github/CODEOWNERS

Required by Salesforce OSPO for the MuleSoft Non-EMU GitHub org transfer.

Related: W-22440070