### PR TITLE
Release v6.6.65

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api-console",
-  "version": "6.6.64",
+  "version": "6.6.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api-console",
-      "version": "6.6.64",
+      "version": "6.6.65",
       "license": "CPAL-1.0",
       "dependencies": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
@@ -16,7 +16,6 @@
         "@api-components/amf-helper-mixin": "^4.5.36",
         "@api-components/api-console-ext-comm": "^3.0.0",
         "@api-components/api-documentation": "^6.1.8",
-        "@api-components/api-method-documentation": "^5.2.30",
         "@api-components/api-navigation": "^4.3.20",
         "@api-components/api-request": "^0.3.8",
         "@api-components/api-summary": "^4.6.16",
@@ -1168,9 +1167,9 @@
       }
     },
     "node_modules/@api-components/api-method-documentation": {
-      "version": "5.2.30",
-      "resolved": "https://registry.npmjs.org/@api-components/api-method-documentation/-/api-method-documentation-5.2.30.tgz",
-      "integrity": "sha512-puuISflImp3pNMTm2CA0Ef1RYW5e7cqU+Xz9eu7OdAWkQiMS1T+bH7VKaeWsVe4Ugez6eOkHVNYrHks2efSTkA==",
+      "version": "5.2.31",
+      "resolved": "https://registry.npmjs.org/@api-components/api-method-documentation/-/api-method-documentation-5.2.31.tgz",
+      "integrity": "sha512-bdouB3vShZiLVcQMjTbD6MT70ljw36OqWyY8EdDBhVrDUSmE5YISQ0l5O8oX3i1c+g/Yjns3eM+vejSHBPZc3Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-icons": "^3.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@api-components/amf-helper-mixin": "^4.5.36",
         "@api-components/api-console-ext-comm": "^3.0.0",
         "@api-components/api-documentation": "^6.1.8",
+        "@api-components/api-method-documentation": "^5.2.30",
         "@api-components/api-navigation": "^4.3.20",
         "@api-components/api-request": "^0.3.8",
         "@api-components/api-summary": "^4.6.16",
@@ -11743,9 +11744,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
-      "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@api-components/amf-helper-mixin": "^4.5.36",
     "@api-components/api-console-ext-comm": "^3.0.0",
     "@api-components/api-documentation": "^6.1.8",
+    "@api-components/api-method-documentation": "^5.2.30",
     "@api-components/api-navigation": "^4.3.20",
     "@api-components/api-request": "^0.3.8",
     "@api-components/api-summary": "^4.6.16",
@@ -155,9 +156,9 @@
     "semver": "7.5.4",
     "decode-uri-component": "0.4.1",
     "set-value": "4.1.0",
-    "dompurify": "3.2.5"
+    "dompurify": "3.4.5"
   },
   "resolutions": {
-    "dompurify": "3.2.5"
+    "dompurify": "3.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-console",
   "description": "The API Console to automatically generate API documentation from RAML and OAS files.",
-  "version": "6.6.64",
+  "version": "6.6.65",
   "license": "CPAL-1.0",
   "main": "index.js",
   "module": "index.js",
@@ -40,7 +40,6 @@
     "@api-components/amf-helper-mixin": "^4.5.36",
     "@api-components/api-console-ext-comm": "^3.0.0",
     "@api-components/api-documentation": "^6.1.8",
-    "@api-components/api-method-documentation": "^5.2.30",
     "@api-components/api-navigation": "^4.3.20",
     "@api-components/api-request": "^0.3.8",
     "@api-components/api-summary": "^4.6.16",


### PR DESCRIPTION
## Updated Components

- @api-components/api-method-documentation: 5.2.30 → 5.2.31 (AsyncAPI operation labels fix)
- dompurify: 3.2.5 → 3.4.5 (CVE fix)

## Related Tickets

- W-22491924: Upgrade DOMPurify to fix CVEs (W-22392962, W-22392963)
- W-21813981: AsyncAPI operations displaying wrong labels in api-method-documentation

## Test Results

- 469 unit tests passed
- 66 visual regression tests passed