### PR TITLE
Release v6.6.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api-console",
-  "version": "6.6.65",
+  "version": "6.6.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api-console",
-      "version": "6.6.65",
+      "version": "6.6.66",
       "license": "CPAL-1.0",
       "dependencies": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
@@ -1338,9 +1338,9 @@
       }
     },
     "node_modules/@api-components/api-responses-document": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@api-components/api-responses-document/-/api-responses-document-4.2.6.tgz",
-      "integrity": "sha512-LPVZmJOWcZCl4l6QK6tiOpiVNEWGbrJVGWBuOY33jNY+TDKLuODy6WpeSogGOz+08vyF70cvsE4ZKW65KkDFrQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@api-components/api-responses-document/-/api-responses-document-4.2.7.tgz",
+      "integrity": "sha512-ldtdNkyycAsqxIy3l1OkUreDX5ZH1d8PR54axs1XJj8EJjL0b77UkV3Nj/QXVZoi6jTh7JU9PqRSzde9JoN9BQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-marked": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-console",
   "description": "The API Console to automatically generate API documentation from RAML and OAS files.",
-  "version": "6.6.65",
+  "version": "6.6.66",
   "license": "CPAL-1.0",
   "main": "index.js",
   "module": "index.js",


### PR DESCRIPTION
## Updated Components

- @api-components/api-responses-document: 4.2.6 → 4.2.7 (transitive, via api-method-documentation)

## Related Tickets

- W-22299818: [APIC] gRPC method response not rendered in documentation tab (Bug)

Fix renders gRPC method response in the documentation tab. Component published to npm as @api-components/api-responses-document@4.2.7.

https://github.com/advanced-rest-client/api-responses-document/pull/44